### PR TITLE
Add floating chatbot assistant

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,10 +103,155 @@
         <p class="footer__legal">La información de este sitio es meramente orientativa y no reemplaza el asesoramiento profesional personalizado.</p>
     </footer>
 
+    <button class="chatbot__toggle" type="button" aria-controls="chatbot" aria-expanded="false">
+        <span class="chatbot__toggle-icon" aria-hidden="true">💬</span>
+        <span class="chatbot__toggle-text">Asistente</span>
+    </button>
+
+    <div id="chatbot" class="chatbot chatbot--closed" role="dialog" aria-modal="false" aria-label="Asistente virtual de Estudio Meraki">
+        <div class="chatbot__header">
+            <div class="chatbot__heading">
+                <p class="chatbot__eyebrow">Asistente virtual</p>
+                <h2 class="chatbot__title">Meraki Chat</h2>
+            </div>
+            <button type="button" class="chatbot__close" aria-label="Cerrar chat">&times;</button>
+        </div>
+        <div class="chatbot__messages" role="log" aria-live="polite"></div>
+        <form class="chatbot__form" autocomplete="off">
+            <label class="visually-hidden" for="chatbot-input">Escribe tu consulta</label>
+            <input id="chatbot-input" class="chatbot__input" type="text" name="mensaje" placeholder="Escribí tu consulta..." required>
+            <button type="submit" class="chatbot__send">Enviar</button>
+        </form>
+    </div>
+
     <script>
         const yearElement = document.getElementById('year');
         const currentYear = new Date().getFullYear();
         yearElement.textContent = currentYear;
+
+        const chatbotToggle = document.querySelector('.chatbot__toggle');
+        const chatbotElement = document.getElementById('chatbot');
+        const chatbotCloseButton = document.querySelector('.chatbot__close');
+        const chatbotForm = document.querySelector('.chatbot__form');
+        const chatbotInput = document.querySelector('.chatbot__input');
+        const chatbotMessages = document.querySelector('.chatbot__messages');
+
+        const knowledgeBase = [
+            {
+                keywords: ['telefono', 'teléfono', 'whatsapp', 'llamar', 'celular'],
+                answer: 'Podés comunicarte al +54 9 11 6257-6017 por llamada o WhatsApp para recibir asesoramiento inmediato.'
+            },
+            {
+                keywords: ['correo', 'mail', 'email'],
+                answer: 'Escribinos a ejcmeraki@gmail.com y te responderemos dentro de las próximas 24 horas hábiles.'
+            },
+            {
+                keywords: ['horario', 'hora', 'cuando', 'disponible'],
+                answer: 'Nuestro equipo responde consultas de lunes a viernes de 9 a 18 h (GMT-3).'
+            },
+            {
+                keywords: ['reunion', 'presencial', 'virtual', 'ubicacion', 'direccion'],
+                answer: 'Agendamos reuniones virtuales y presenciales con coordinación previa en Ciudad de Buenos Aires.'
+            },
+            {
+                keywords: ['servicios', 'areas', 'ofrecen', 'ayuda', 'especialidad'],
+                answer: 'Asistimos en constitución de sociedades, gestión contable, impuestos y representación legal integral para emprendedores y pymes.'
+            },
+            {
+                keywords: ['honorarios', 'costo', 'precio', 'tarifa'],
+                answer: 'Determinamos los honorarios según el alcance del caso. Contanos más detalles y te enviaremos una propuesta a medida.'
+            },
+            {
+                keywords: ['documentacion', 'documentos', 'informacion', 'datos'],
+                answer: 'Podés adjuntar documentación relevante cuando coordinemos la reunión o enviarla por correo seguro para agilizar el análisis.'
+            },
+            {
+                keywords: ['gracias', 'gracias!'],
+                answer: '¡Gracias a vos por escribirnos! ¿Hay algo más en lo que podamos ayudarte?'
+            }
+        ];
+
+        function normalize(text) {
+            return text
+                .toLowerCase()
+                .normalize('NFD')
+                .replace(/[\u0300-\u036f]/g, '');
+        }
+
+        function toggleChat(forceOpen) {
+            const shouldOpen = forceOpen !== undefined ? forceOpen : chatbotElement.classList.contains('chatbot--closed');
+
+            if (shouldOpen) {
+                chatbotElement.classList.add('chatbot--open');
+                chatbotElement.classList.remove('chatbot--closed');
+                chatbotToggle.setAttribute('aria-expanded', 'true');
+                chatbotToggle.classList.add('chatbot__toggle--active');
+                chatbotInput.focus();
+            } else {
+                chatbotElement.classList.remove('chatbot--open');
+                chatbotElement.classList.add('chatbot--closed');
+                chatbotToggle.setAttribute('aria-expanded', 'false');
+                chatbotToggle.classList.remove('chatbot__toggle--active');
+            }
+        }
+
+        function addMessage(text, sender) {
+            const bubble = document.createElement('div');
+            bubble.className = `chatbot__bubble chatbot__bubble--${sender}`;
+            const paragraph = document.createElement('p');
+            paragraph.textContent = text;
+            bubble.appendChild(paragraph);
+            chatbotMessages.appendChild(bubble);
+            chatbotMessages.scrollTop = chatbotMessages.scrollHeight;
+        }
+
+        function getResponse(message) {
+            const normalizedMessage = normalize(message);
+
+            for (const entry of knowledgeBase) {
+                const hasMatch = entry.keywords.some((keyword) => normalizedMessage.includes(normalize(keyword)));
+                if (hasMatch) {
+                    return entry.answer;
+                }
+            }
+
+            return 'Gracias por tu consulta. Para brindarte la mejor respuesta, contanos más detalles o escribinos a ejcmeraki@gmail.com.';
+        }
+
+        function handleSubmit(event) {
+            event.preventDefault();
+            const userMessage = chatbotInput.value.trim();
+
+            if (!userMessage) {
+                return;
+            }
+
+            addMessage(userMessage, 'user');
+            chatbotInput.value = '';
+
+            window.requestAnimationFrame(() => {
+                const response = getResponse(userMessage);
+                setTimeout(() => addMessage(response, 'bot'), 350);
+            });
+        }
+
+        chatbotToggle.addEventListener('click', () => {
+            const isClosed = chatbotElement.classList.contains('chatbot--closed');
+            toggleChat(isClosed);
+            if (isClosed && chatbotMessages.childElementCount === 0) {
+                addMessage('¡Hola! Soy el asistente virtual de Estudio Meraki. Contame cómo podemos ayudarte.', 'bot');
+            }
+        });
+
+        chatbotCloseButton.addEventListener('click', () => toggleChat(false));
+
+        chatbotForm.addEventListener('submit', handleSubmit);
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && chatbotElement.classList.contains('chatbot--open')) {
+                toggleChat(false);
+            }
+        });
     </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -424,3 +424,268 @@ main {
         padding: 0.9rem 2rem;
     }
 }
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.chatbot__toggle {
+    position: fixed;
+    bottom: 1.75rem;
+    right: 1.75rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.95rem 1.35rem;
+    border: none;
+    border-radius: 999px;
+    background: linear-gradient(135deg, var(--color-secondary), var(--color-primary));
+    color: #ffffff;
+    font-family: var(--font-body);
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    box-shadow: 0 20px 40px -24px rgba(29, 71, 85, 0.8);
+    transition: transform 0.2s ease, box-shadow 0.3s ease, background 0.3s ease;
+    z-index: 1050;
+}
+
+.chatbot__toggle:hover,
+.chatbot__toggle:focus {
+    outline: none;
+    transform: translateY(-2px);
+    box-shadow: 0 22px 45px -20px rgba(29, 71, 85, 0.75);
+}
+
+.chatbot__toggle:focus-visible {
+    box-shadow: 0 0 0 4px rgba(140, 199, 195, 0.35);
+}
+
+.chatbot__toggle--active {
+    background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
+}
+
+.chatbot__toggle-icon {
+    font-size: 1.2rem;
+}
+
+.chatbot__toggle-text {
+    font-size: 0.95rem;
+}
+
+.chatbot {
+    position: fixed;
+    bottom: 6.5rem;
+    right: 1.75rem;
+    width: 320px;
+    max-width: calc(100% - 2.5rem);
+    background: var(--color-surface);
+    border-radius: 22px;
+    box-shadow: 0 35px 65px -40px rgba(15, 37, 46, 0.75);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    transition: opacity 0.25s ease, transform 0.3s ease;
+    z-index: 1040;
+}
+
+.chatbot--closed {
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(18px);
+    pointer-events: none;
+}
+
+.chatbot--open {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+    pointer-events: auto;
+}
+
+.chatbot__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1.25rem 1.35rem 1.1rem;
+    background: linear-gradient(135deg, rgba(29, 71, 85, 0.98), rgba(47, 108, 124, 0.95));
+    color: #ffffff;
+}
+
+.chatbot__heading {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.chatbot__eyebrow {
+    font-size: 0.68rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    opacity: 0.75;
+}
+
+.chatbot__title {
+    font-family: var(--font-heading);
+    font-size: 1.25rem;
+    line-height: 1.3;
+}
+
+.chatbot__close {
+    border: none;
+    background: rgba(255, 255, 255, 0.12);
+    color: #ffffff;
+    font-size: 1.5rem;
+    width: 2.2rem;
+    height: 2.2rem;
+    border-radius: 999px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.chatbot__close:hover,
+.chatbot__close:focus {
+    background: rgba(255, 255, 255, 0.22);
+    transform: translateY(-1px);
+}
+
+.chatbot__close:focus-visible {
+    box-shadow: 0 0 0 3px rgba(140, 199, 195, 0.4);
+    outline: none;
+}
+
+.chatbot__messages {
+    padding: 1.25rem 1.35rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    max-height: 320px;
+    overflow-y: auto;
+    background: rgba(48, 86, 102, 0.06);
+}
+
+.chatbot__messages::-webkit-scrollbar {
+    width: 6px;
+}
+
+.chatbot__messages::-webkit-scrollbar-thumb {
+    background: rgba(47, 108, 124, 0.45);
+    border-radius: 999px;
+}
+
+.chatbot__bubble {
+    align-self: flex-start;
+    max-width: 85%;
+    padding: 0.75rem 1rem;
+    border-radius: 16px;
+    font-size: 0.95rem;
+    line-height: 1.45;
+    box-shadow: 0 12px 32px -28px rgba(15, 37, 46, 0.65);
+    background: #ffffff;
+    color: var(--color-text);
+}
+
+.chatbot__bubble--bot {
+    background: #ffffff;
+}
+
+.chatbot__bubble--user {
+    align-self: flex-end;
+    background: linear-gradient(135deg, rgba(47, 108, 124, 0.9), rgba(29, 71, 85, 0.95));
+    color: #ffffff;
+}
+
+.chatbot__form {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 1rem 1.35rem 1.35rem;
+    background: var(--color-surface);
+    border-top: 1px solid rgba(29, 71, 85, 0.08);
+}
+
+.chatbot__input {
+    flex: 1;
+    border: 1px solid rgba(29, 71, 85, 0.25);
+    border-radius: 999px;
+    padding: 0.7rem 1rem;
+    font: inherit;
+    background-color: rgba(255, 255, 255, 0.95);
+    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.chatbot__input:focus {
+    outline: none;
+    border-color: var(--color-secondary);
+    box-shadow: 0 0 0 4px rgba(140, 199, 195, 0.25);
+}
+
+.chatbot__send {
+    border: none;
+    border-radius: 999px;
+    padding: 0.7rem 1.35rem;
+    background: linear-gradient(135deg, var(--color-secondary), var(--color-primary));
+    color: #ffffff;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chatbot__send:hover,
+.chatbot__send:focus {
+    outline: none;
+    transform: translateY(-1px);
+    box-shadow: 0 14px 26px -20px rgba(29, 71, 85, 0.8);
+}
+
+.chatbot__send:focus-visible {
+    box-shadow: 0 0 0 3px rgba(140, 199, 195, 0.35);
+}
+
+@media (max-width: 768px) {
+    .chatbot {
+        right: 1.25rem;
+        bottom: 6rem;
+        max-width: calc(100% - 2.5rem);
+    }
+
+    .chatbot__toggle {
+        right: 1.25rem;
+        bottom: 1.5rem;
+    }
+}
+
+@media (max-width: 540px) {
+    .chatbot {
+        width: calc(100% - 1.5rem);
+        right: 0.75rem;
+        bottom: 5.75rem;
+        border-radius: 18px;
+    }
+
+    .chatbot__toggle {
+        right: 0.75rem;
+        bottom: 1.25rem;
+        padding: 0.85rem 1.1rem;
+    }
+
+    .chatbot__toggle-text {
+        display: none;
+    }
+
+    .chatbot__messages {
+        max-height: 260px;
+    }
+}


### PR DESCRIPTION
## Summary
- add floating action button and chat panel markup to index.html
- add responsive styling for the chatbot components in styles.css
- implement FAQ-based chatbot interactions with keyword matching and toggling logic

## Testing
- python -m http.server 8000 (manual verification with desktop and mobile viewports)


------
https://chatgpt.com/codex/tasks/task_e_68d2c86d9cdc833285e73900c4812de7