### PR TITLE
Add chatbot quick suggestion buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,8 +119,15 @@
         <div class="chatbot__messages" role="log" aria-live="polite"></div>
         <form class="chatbot__form" autocomplete="off">
             <label class="visually-hidden" for="chatbot-input">Escribe tu consulta</label>
-            <input id="chatbot-input" class="chatbot__input" type="text" name="mensaje" placeholder="Escribí tu consulta..." required>
-            <button type="submit" class="chatbot__send">Enviar</button>
+            <div class="chatbot__suggestions" aria-label="Preguntas rápidas">
+                <button type="button" class="chatbot__suggestion" data-message="¿Cuál es el horario?">¿Cuál es el horario?</button>
+                <button type="button" class="chatbot__suggestion" data-message="Contacto por WhatsApp">Contacto por WhatsApp</button>
+                <button type="button" class="chatbot__suggestion" data-message="¿Qué servicios ofrecen?">¿Qué servicios ofrecen?</button>
+            </div>
+            <div class="chatbot__controls">
+                <input id="chatbot-input" class="chatbot__input" type="text" name="mensaje" placeholder="Escribí tu consulta..." required>
+                <button type="submit" class="chatbot__send">Enviar</button>
+            </div>
         </form>
     </div>
 
@@ -135,6 +142,7 @@
         const chatbotForm = document.querySelector('.chatbot__form');
         const chatbotInput = document.querySelector('.chatbot__input');
         const chatbotMessages = document.querySelector('.chatbot__messages');
+        const suggestionButtons = document.querySelectorAll('.chatbot__suggestion');
 
         const knowledgeBase = [
             {
@@ -218,6 +226,19 @@
             return 'Gracias por tu consulta. Para brindarte la mejor respuesta, contanos más detalles o escribinos a ejcmeraki@gmail.com.';
         }
 
+        function processUserMessage(message) {
+            if (!message) {
+                return;
+            }
+
+            addMessage(message, 'user');
+
+            window.requestAnimationFrame(() => {
+                const response = getResponse(message);
+                setTimeout(() => addMessage(response, 'bot'), 350);
+            });
+        }
+
         function handleSubmit(event) {
             event.preventDefault();
             const userMessage = chatbotInput.value.trim();
@@ -226,13 +247,8 @@
                 return;
             }
 
-            addMessage(userMessage, 'user');
             chatbotInput.value = '';
-
-            window.requestAnimationFrame(() => {
-                const response = getResponse(userMessage);
-                setTimeout(() => addMessage(response, 'bot'), 350);
-            });
+            processUserMessage(userMessage);
         }
 
         chatbotToggle.addEventListener('click', () => {
@@ -246,6 +262,14 @@
         chatbotCloseButton.addEventListener('click', () => toggleChat(false));
 
         chatbotForm.addEventListener('submit', handleSubmit);
+
+        suggestionButtons.forEach((button) => {
+            button.addEventListener('click', () => {
+                const suggestedMessage = button.dataset.message?.trim();
+                processUserMessage(suggestedMessage);
+                chatbotInput.focus();
+            });
+        });
 
         document.addEventListener('keydown', (event) => {
             if (event.key === 'Escape' && chatbotElement.classList.contains('chatbot--open')) {

--- a/styles.css
+++ b/styles.css
@@ -609,11 +609,52 @@ main {
 
 .chatbot__form {
     display: flex;
-    align-items: center;
-    gap: 0.65rem;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.85rem;
     padding: 1rem 1.35rem 1.35rem;
     background: var(--color-surface);
     border-top: 1px solid rgba(29, 71, 85, 0.08);
+}
+
+.chatbot__suggestions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    background: rgba(48, 86, 102, 0.06);
+    border-radius: 14px;
+    padding: 0.65rem;
+}
+
+.chatbot__suggestion {
+    border: 1px solid rgba(29, 71, 85, 0.25);
+    border-radius: 999px;
+    padding: 0.35rem 0.85rem;
+    background: rgba(255, 255, 255, 0.92);
+    color: var(--color-primary);
+    font: inherit;
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.chatbot__suggestion:hover,
+.chatbot__suggestion:focus {
+    outline: none;
+    background: rgba(140, 199, 195, 0.25);
+    border-color: rgba(47, 108, 124, 0.55);
+    transform: translateY(-1px);
+}
+
+.chatbot__suggestion:focus-visible {
+    box-shadow: 0 0 0 3px rgba(140, 199, 195, 0.35);
+}
+
+.chatbot__controls {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
 }
 
 .chatbot__input {


### PR DESCRIPTION
## Summary
- add quick-access suggestion buttons for frequent chatbot consultas
- style the suggestions area and input controls to keep a responsive layout
- reuse the chatbot response logic when a suggestion is selected

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d2cdf221b88332acab19b9d2f133fd