### PR TITLE
Add contact form status messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
                     </div>
                     <p class="form__help">Respondemos dentro de las próximas 24 horas hábiles.</p>
                     <button type="submit" class="button">Enviar consulta</button>
+                    <p class="form__status" role="status" aria-live="polite" aria-atomic="true" aria-hidden="true"></p>
                 </form>
             </div>
         </section>
@@ -143,6 +144,9 @@
         const chatbotInput = document.querySelector('.chatbot__input');
         const chatbotMessages = document.querySelector('.chatbot__messages');
         const suggestionButtons = document.querySelectorAll('.chatbot__suggestion');
+        const contactForm = document.querySelector('.contact__form');
+        const formStatus = contactForm ? contactForm.querySelector('.form__status') : null;
+        const contactSubmitButton = contactForm ? contactForm.querySelector('button[type="submit"]') : null;
 
         const knowledgeBase = [
             {
@@ -276,6 +280,129 @@
                 toggleChat(false);
             }
         });
+
+        if (contactForm && formStatus) {
+            const statusClasses = ['form__status--success', 'form__status--error', 'form__status--visible'];
+
+            const updateFormStatus = (message = '', type) => {
+                formStatus.textContent = message;
+                formStatus.classList.remove(...statusClasses);
+
+                if (message) {
+                    formStatus.classList.add('form__status--visible');
+
+                    if (type) {
+                        formStatus.classList.add(`form__status--${type}`);
+                    }
+
+                    formStatus.setAttribute('aria-hidden', 'false');
+                } else {
+                    formStatus.setAttribute('aria-hidden', 'true');
+                }
+            };
+
+            const validateEmail = (value) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+
+            contactForm.addEventListener('submit', async (event) => {
+                event.preventDefault();
+
+                updateFormStatus('', null);
+
+                const formData = new FormData(contactForm);
+                const nombre = (formData.get('nombre') || '').toString().trim();
+                const email = (formData.get('email') || '').toString().trim();
+                const mensaje = (formData.get('mensaje') || '').toString().trim();
+
+                const validationErrors = [];
+                const isEmailValid = email && validateEmail(email);
+
+                if (!nombre) {
+                    validationErrors.push('Ingresá tu nombre completo.');
+                }
+
+                if (!email) {
+                    validationErrors.push('Ingresá un correo electrónico de contacto.');
+                } else if (!isEmailValid) {
+                    validationErrors.push('Revisá que el correo electrónico tenga un formato válido.');
+                }
+
+                if (!mensaje) {
+                    validationErrors.push('Contanos brevemente tu consulta para poder ayudarte.');
+                }
+
+                if (validationErrors.length > 0) {
+                    updateFormStatus(validationErrors.join(' '), 'error');
+
+                    if (!nombre) {
+                        contactForm.elements.nombre.focus();
+                    } else if (!email || !isEmailValid) {
+                        contactForm.elements.email.focus();
+                    } else if (!mensaje) {
+                        contactForm.elements.mensaje.focus();
+                    }
+
+                    return;
+                }
+
+                updateFormStatus('Enviando tu consulta...', null);
+
+                if (contactSubmitButton) {
+                    contactSubmitButton.setAttribute('disabled', 'true');
+                    contactSubmitButton.setAttribute('aria-busy', 'true');
+                }
+
+                const endpoint = (contactForm.getAttribute('action') || '').trim();
+                const method = (contactForm.getAttribute('method') || 'POST').toUpperCase();
+                const shouldSubmitRemotely = endpoint && endpoint !== '#';
+
+                try {
+                    if (shouldSubmitRemotely) {
+                        const requestInit = {
+                            method,
+                            headers: {
+                                Accept: 'application/json'
+                            }
+                        };
+
+                        if (method === 'GET') {
+                            const query = new URLSearchParams(formData).toString();
+                            const requestUrl = endpoint.includes('?') ? `${endpoint}&${query}` : `${endpoint}?${query}`;
+                            const response = await fetch(requestUrl, requestInit);
+
+                            if (!response.ok) {
+                                throw new Error('Error al enviar la consulta');
+                            }
+                        } else {
+                            requestInit.body = formData;
+                            const response = await fetch(endpoint, requestInit);
+
+                            if (!response.ok) {
+                                throw new Error('Error al enviar la consulta');
+                            }
+                        }
+                    } else {
+                        await new Promise((resolve) => setTimeout(resolve, 600));
+                    }
+
+                    updateFormStatus('¡Gracias! Recibimos tu consulta y te responderemos a la brevedad.', 'success');
+                    contactForm.reset();
+                } catch (error) {
+                    console.error(error);
+                    updateFormStatus('No pudimos enviar tu consulta en este momento. Intentá nuevamente más tarde o utilizá nuestros medios alternativos de contacto.', 'error');
+                } finally {
+                    if (contactSubmitButton) {
+                        contactSubmitButton.removeAttribute('disabled');
+                        contactSubmitButton.removeAttribute('aria-busy');
+                    }
+                }
+            });
+
+            contactForm.addEventListener('input', () => {
+                if (formStatus.classList.contains('form__status--error')) {
+                    updateFormStatus('', null);
+                }
+            });
+        }
     </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -260,6 +260,60 @@ main {
     color: var(--color-muted);
 }
 
+.form__status {
+    grid-column: 1 / -1;
+    display: none;
+    align-items: center;
+    gap: 0.65rem;
+    margin-top: -0.25rem;
+    padding: 0.9rem 1rem;
+    border-radius: 14px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    line-height: 1.4;
+    background: rgba(255, 255, 255, 0.95);
+    box-shadow: inset 0 0 0 1px rgba(29, 71, 85, 0.1);
+    color: var(--color-muted);
+    opacity: 0;
+    transform: translateY(-4px);
+    transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.form__status::before {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1rem;
+}
+
+.form__status--visible {
+    display: flex;
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.form__status--success {
+    background: rgba(140, 199, 195, 0.22);
+    color: var(--color-primary);
+    box-shadow: inset 0 0 0 1px rgba(140, 199, 195, 0.4);
+}
+
+.form__status--success::before {
+    content: '✔';
+    color: var(--color-secondary);
+}
+
+.form__status--error {
+    background: rgba(29, 71, 85, 0.12);
+    color: var(--color-secondary);
+    box-shadow: inset 0 0 0 1px rgba(29, 71, 85, 0.25);
+}
+
+.form__status--error::before {
+    content: '⚠';
+    color: var(--color-secondary);
+}
+
 .button {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- add an aria-live status placeholder below the contact form button to present feedback messages
- intercept form submissions to validate fields, surface pending/success/error states and simulate/handle remote requests
- style the new status element and its success/error variants in line with the existing palette

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2d2c4d13083329c2566e664388d24