### PR TITLE
Refine landing page layout with accordion service menus

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,326 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Estudio Meraki - Contacto</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;700&family=Work+Sans:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <div class="hero__content">
+        <img src="assets/logo-meraki.svg" alt="Logotipo Estudio Meraki" class="hero__logo" />
+        <p class="hero__tagline">Soluciones legales y contables a medida</p>
+        <h1 class="hero__title">Estudio Meraki</h1>
+        <p class="hero__description">
+          Acompañamos a personas, familias y empresas con un servicio cercano, profesional y
+          estratégico. Creemos en el asesoramiento integral, la comunicación clara y la confianza
+          como base de cada vínculo.
+        </p>
+        <div class="hero__actions">
+          <a class="button button--primary" href="#asesoramiento">Conocé nuestros servicios</a>
+          <a class="button" href="https://wa.me/5491122334455" target="_blank" rel="noopener">WhatsApp directo</a>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section class="about" id="sobre-nosotros">
+        <div class="about__intro">
+          <span class="about__eyebrow">Sobre el estudio</span>
+          <h2>Un equipo interdisciplinario comprometido con tus proyectos</h2>
+          <p>
+            Somos abogadas y contadoras que unimos experiencia jurídica y contable para brindar
+            respuestas ágiles y personalizadas. Nos enfocamos en escuchar, diagnosticar y proponer
+            estrategias legales integrales que acompañen cada etapa de tu vida o negocio.
+          </p>
+        </div>
+        <div class="about__grid">
+          <article class="about__card">
+            <h3>👥 Trato humano y cercano</h3>
+            <p>
+              Nos involucramos en cada caso con empatía, respeto y confidencialidad. Queremos que
+              sientas al estudio como tu aliado de confianza.
+            </p>
+          </article>
+          <article class="about__card">
+            <h3>📚 Actualización constante</h3>
+            <p>
+              Participamos activamente en capacitaciones y redes profesionales para brindarte
+              asesoramiento actualizado y creativo.
+            </p>
+          </article>
+          <article class="about__card">
+            <h3>🤝 Acompañamiento integral</h3>
+            <p>
+              Trabajamos de manera coordinada entre áreas legales y contables para ofrecer soluciones
+              preventivas y estrategias sólidas.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="advisory" id="asesoramiento">
+        <div class="advisory__header">
+          <span class="advisory__eyebrow">Áreas de práctica</span>
+          <h2>Seleccioná el asesoramiento que necesitás</h2>
+          <p>
+            Desplegá cada especialidad para conocer las gestiones que podemos acompañar. Si no
+            encontrás lo que buscás, escribinos y armamos una propuesta a tu medida.
+          </p>
+        </div>
+        <div class="accordion" role="list">
+          <article class="accordion__item" role="listitem">
+            <h3>
+              <button
+                class="accordion__trigger"
+                type="button"
+                id="trigger-inmobiliario"
+                aria-expanded="false"
+                aria-controls="panel-inmobiliario"
+              >
+                <span class="accordion__title"><span class="accordion__emoji">🏡</span> Derecho inmobiliario</span>
+                <span class="accordion__icon" aria-hidden="true">+</span>
+              </button>
+            </h3>
+            <div class="accordion__content" id="panel-inmobiliario" role="region" aria-labelledby="trigger-inmobiliario" hidden>
+              <ul class="accordion__list">
+                <li>Boleto de compraventa y etapas previas a la escritura</li>
+                <li>Contratos de locación para vivienda, comerciales y temporarios</li>
+                <li>Asesoría integral en operaciones inmobiliarias</li>
+                <li>Trámites registrales y regularización de inmuebles</li>
+                <li>Fideicomisos: constitución, administración y seguimiento legal</li>
+              </ul>
+            </div>
+          </article>
+          <article class="accordion__item" role="listitem">
+            <h3>
+              <button
+                class="accordion__trigger"
+                type="button"
+                id="trigger-familia"
+                aria-expanded="false"
+                aria-controls="panel-familia"
+              >
+                <span class="accordion__title"><span class="accordion__emoji">👨‍👩‍👧</span> Derecho de familia</span>
+                <span class="accordion__icon" aria-hidden="true">+</span>
+              </button>
+            </h3>
+            <div class="accordion__content" id="panel-familia" role="region" aria-labelledby="trigger-familia" hidden>
+              <ul class="accordion__list">
+                <li>Sucesiones y planificación hereditaria</li>
+                <li>Divorcios de común acuerdo o contenciosos</li>
+                <li>Convenios de alimentos, tenencia y régimen de visitas</li>
+                <li>Procesos de adopción y filiación</li>
+                <li>Violencia familiar y medidas cautelares</li>
+              </ul>
+            </div>
+          </article>
+          <article class="accordion__item" role="listitem">
+            <h3>
+              <button
+                class="accordion__trigger"
+                type="button"
+                id="trigger-laboral"
+                aria-expanded="false"
+                aria-controls="panel-laboral"
+              >
+                <span class="accordion__title"><span class="accordion__emoji">💼</span> Derecho laboral</span>
+                <span class="accordion__icon" aria-hidden="true">+</span>
+              </button>
+            </h3>
+            <div class="accordion__content" id="panel-laboral" role="region" aria-labelledby="trigger-laboral" hidden>
+              <ul class="accordion__list">
+                <li>Asesoramiento a empleadores y trabajadores</li>
+                <li>Reclamos por despidos, indemnizaciones y accidentes laborales</li>
+                <li>Liquidaciones finales y cálculo de haberes</li>
+                <li>Negociaciones individuales y colectivas</li>
+                <li>Representación ante el Ministerio de Trabajo</li>
+              </ul>
+            </div>
+          </article>
+          <article class="accordion__item" role="listitem">
+            <h3>
+              <button
+                class="accordion__trigger"
+                type="button"
+                id="trigger-comercial"
+                aria-expanded="false"
+                aria-controls="panel-comercial"
+              >
+                <span class="accordion__title"><span class="accordion__emoji">📄</span> Derecho comercial y societario</span>
+                <span class="accordion__icon" aria-hidden="true">+</span>
+              </button>
+            </h3>
+            <div class="accordion__content" id="panel-comercial" role="region" aria-labelledby="trigger-comercial" hidden>
+              <ul class="accordion__list">
+                <li>Constitución de sociedades (SRL, SA, SAS)</li>
+                <li>Redacción de estatutos, contratos y actas societarias</li>
+                <li>Reestructuraciones y acuerdos entre socios</li>
+                <li>Asesoramiento en contratos comerciales y civiles</li>
+              </ul>
+            </div>
+          </article>
+          <article class="accordion__item" role="listitem">
+            <h3>
+              <button
+                class="accordion__trigger"
+                type="button"
+                id="trigger-civil"
+                aria-expanded="false"
+                aria-controls="panel-civil"
+              >
+                <span class="accordion__title"><span class="accordion__emoji">⚖️</span> Derecho civil</span>
+                <span class="accordion__icon" aria-hidden="true">+</span>
+              </button>
+            </h3>
+            <div class="accordion__content" id="panel-civil" role="region" aria-labelledby="trigger-civil" hidden>
+              <ul class="accordion__list">
+                <li>Redacción y revisión de contratos</li>
+                <li>Reclamos por daños y perjuicios</li>
+                <li>Cobro de deudas y ejecuciones</li>
+                <li>Defensa en juicios civiles</li>
+                <li>Acciones de amparo</li>
+              </ul>
+            </div>
+          </article>
+          <article class="accordion__item" role="listitem">
+            <h3>
+              <button
+                class="accordion__trigger"
+                type="button"
+                id="trigger-penal"
+                aria-expanded="false"
+                aria-controls="panel-penal"
+              >
+                <span class="accordion__title"><span class="accordion__emoji">🛡️</span> Derecho penal</span>
+                <span class="accordion__icon" aria-hidden="true">+</span>
+              </button>
+            </h3>
+            <div class="accordion__content" id="panel-penal" role="region" aria-labelledby="trigger-penal" hidden>
+              <ul class="accordion__list">
+                <li>Defensa en causas penales</li>
+                <li>Denuncias, querellas y asistencia a víctimas</li>
+                <li>Excarcelaciones y medidas cautelares</li>
+                <li>Estrategias preventivas y compliance penal</li>
+              </ul>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="contact" id="contacto">
+        <div class="contact__intro">
+          <span class="contact__eyebrow">Agendemos una reunión</span>
+          <h2>Contanos en qué podemos ayudarte</h2>
+          <p>
+            Completá el formulario o elegí el medio que prefieras. Respondemos dentro de las 24
+            horas hábiles y coordinamos el seguimiento de tu consulta.
+          </p>
+        </div>
+        <div class="contact__grid">
+          <div class="contact__card">
+            <h3>Datos de contacto</h3>
+            <ul class="contact__list">
+              <li>
+                <span class="contact__label">Teléfono</span>
+                <a href="tel:+541123334455">+54 11 2333 4455</a>
+              </li>
+              <li>
+                <span class="contact__label">Email</span>
+                <a href="mailto:hola@estudiomeraki.com">hola@estudiomeraki.com</a>
+              </li>
+              <li>
+                <span class="contact__label">Dirección</span>
+                <address>
+                  Av. Callao 1234, Piso 3 Oficina B<br />
+                  Ciudad Autónoma de Buenos Aires
+                </address>
+              </li>
+              <li>
+                <span class="contact__label">Horarios</span>
+                <p>Lunes a Viernes de 9 a 18 h</p>
+              </li>
+            </ul>
+          </div>
+
+          <form class="form" action="#" method="post">
+            <h3>Enviá tu consulta</h3>
+            <label class="form__field">
+              <span>Nombre completo</span>
+              <input type="text" name="nombre" placeholder="María Pérez" required />
+            </label>
+            <label class="form__field">
+              <span>Email</span>
+              <input type="email" name="email" placeholder="nombre@correo.com" required />
+            </label>
+            <label class="form__field">
+              <span>Teléfono</span>
+              <input type="tel" name="telefono" placeholder="11 2345 6789" />
+            </label>
+            <label class="form__field">
+              <span>Motivo de la consulta</span>
+              <select name="motivo" required>
+                <option value="" disabled selected>Elegí una opción</option>
+                <option value="inmobiliario">Derecho inmobiliario</option>
+                <option value="familia">Derecho de familia</option>
+                <option value="laboral">Derecho laboral</option>
+                <option value="comercial">Derecho comercial y societario</option>
+                <option value="civil">Derecho civil</option>
+                <option value="penal">Derecho penal</option>
+                <option value="otros">Otros</option>
+              </select>
+            </label>
+            <label class="form__field form__field--textarea">
+              <span>Contanos más detalles</span>
+              <textarea name="mensaje" rows="4" placeholder="Describí tu consulta"></textarea>
+            </label>
+            <button type="submit" class="button button--primary">Enviar consulta</button>
+            <p class="form__disclaimer">
+              Al enviar tus datos aceptás ser contactado/a por un representante del Estudio Meraki.
+            </p>
+          </form>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>© <span id="year"></span> Estudio Meraki. Todos los derechos reservados.</p>
+      <nav class="footer__nav">
+        <a href="#sobre-nosotros">El estudio</a>
+        <a href="#asesoramiento">Servicios</a>
+        <a href="#contacto">Contacto</a>
+        <a href="https://wa.me/5491122334455" target="_blank" rel="noopener">WhatsApp</a>
+      </nav>
+    </footer>
+
+    <script>
+      const yearElement = document.getElementById("year");
+      if (yearElement) {
+        yearElement.textContent = new Date().getFullYear();
+      }
+
+      const accordionTriggers = document.querySelectorAll(".accordion__trigger");
+      accordionTriggers.forEach((trigger) => {
+        const content = document.getElementById(trigger.getAttribute("aria-controls"));
+        const icon = trigger.querySelector(".accordion__icon");
+        trigger.addEventListener("click", () => {
+          const isExpanded = trigger.getAttribute("aria-expanded") === "true";
+          trigger.setAttribute("aria-expanded", String(!isExpanded));
+          if (content) {
+            content.hidden = isExpanded;
+          }
+          if (icon) {
+            icon.textContent = isExpanded ? "+" : "−";
+          }
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Estudio Meraki - Contacto</title>
+    <title>Estudio Meraki · Asesoramiento legal y contable</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -13,242 +13,205 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <header class="hero">
-      <div class="hero__content">
-        <img src="assets/logo-meraki.svg" alt="Logotipo Estudio Meraki" class="hero__logo" />
-        <p class="hero__tagline">Soluciones legales y contables a medida</p>
+    <header class="site-header" id="inicio">
+      <div class="site-header__inner">
+        <img src="assets/logo-meraki.svg" alt="Logotipo Estudio Meraki" class="brand" />
+        <nav class="site-nav" aria-label="Navegación principal">
+          <a href="#sobre-el-estudio">El estudio</a>
+          <a href="#servicios">Servicios</a>
+          <a href="#contacto">Contacto</a>
+          <a class="site-nav__cta" href="https://wa.me/5491122334455" target="_blank" rel="noopener">
+            WhatsApp directo
+          </a>
+        </nav>
+      </div>
+      <div class="hero">
+        <p class="hero__kicker">Soluciones legales y contables a medida</p>
         <h1 class="hero__title">Estudio Meraki</h1>
-        <p class="hero__description">
-          Acompañamos a personas, familias y empresas con un servicio cercano, profesional y
-          estratégico. Creemos en el asesoramiento integral, la comunicación clara y la confianza
-          como base de cada vínculo.
+        <p class="hero__lead">
+          Acompañamos a personas, familias y empresas con una mirada integral. Nos enfocamos en la
+          escucha activa, el análisis preciso y la creación de estrategias que generen confianza a largo
+          plazo.
         </p>
         <div class="hero__actions">
-          <a class="button button--primary" href="#asesoramiento">Conocé nuestros servicios</a>
-          <a class="button" href="https://wa.me/5491122334455" target="_blank" rel="noopener">WhatsApp directo</a>
+          <a class="button button--primary" href="#servicios">Conocé nuestros servicios</a>
+          <a class="button" href="#contacto">Reservá una reunión</a>
         </div>
       </div>
     </header>
 
     <main>
-      <section class="about" id="sobre-nosotros">
-        <div class="about__intro">
-          <span class="about__eyebrow">Sobre el estudio</span>
+      <section class="about" id="sobre-el-estudio">
+        <div class="section-heading">
+          <span class="section-heading__eyebrow">Sobre el estudio</span>
           <h2>Un equipo interdisciplinario comprometido con tus proyectos</h2>
           <p>
-            Somos abogadas y contadoras que unimos experiencia jurídica y contable para brindar
-            respuestas ágiles y personalizadas. Nos enfocamos en escuchar, diagnosticar y proponer
-            estrategias legales integrales que acompañen cada etapa de tu vida o negocio.
+            Somos abogadas y contadoras que unen experiencia jurídica y contable para acompañarte con un
+            servicio personalizado. Diseñamos soluciones que contemplan la dimensión humana, financiera y
+            legal de cada caso.
           </p>
         </div>
         <div class="about__grid">
-          <article class="about__card">
-            <h3>👥 Trato humano y cercano</h3>
+          <article class="about-card">
+            <h3>👥 Acompañamiento cercano</h3>
             <p>
-              Nos involucramos en cada caso con empatía, respeto y confidencialidad. Queremos que
-              sientas al estudio como tu aliado de confianza.
+              Generamos vínculos de confianza a través de reuniones periódicas, seguimiento activo y
+              comunicación clara en cada instancia del proceso.
             </p>
           </article>
-          <article class="about__card">
-            <h3>📚 Actualización constante</h3>
+          <article class="about-card">
+            <h3>📚 Actualización permanente</h3>
             <p>
-              Participamos activamente en capacitaciones y redes profesionales para brindarte
-              asesoramiento actualizado y creativo.
+              Participamos en capacitaciones y redes profesionales para ofrecerte respuestas ágiles basadas
+              en la normativa vigente y las mejores prácticas del mercado.
             </p>
           </article>
-          <article class="about__card">
-            <h3>🤝 Acompañamiento integral</h3>
+          <article class="about-card">
+            <h3>🤝 Visión integral</h3>
             <p>
-              Trabajamos de manera coordinada entre áreas legales y contables para ofrecer soluciones
-              preventivas y estrategias sólidas.
+              Articulamos la mirada legal y contable para anticipar riesgos, optimizar recursos y diseñar
+              estrategias sostenibles para tu vida o negocio.
             </p>
           </article>
         </div>
       </section>
 
-      <section class="advisory" id="asesoramiento">
-        <div class="advisory__header">
-          <span class="advisory__eyebrow">Áreas de práctica</span>
+      <section class="services" id="servicios">
+        <div class="section-heading section-heading--center">
+          <span class="section-heading__eyebrow">Áreas de práctica</span>
           <h2>Seleccioná el asesoramiento que necesitás</h2>
           <p>
-            Desplegá cada especialidad para conocer las gestiones que podemos acompañar. Si no
-            encontrás lo que buscás, escribinos y armamos una propuesta a tu medida.
+            Desplegá cada especialidad para conocer las gestiones en las que podemos acompañarte. Si tenés
+            un caso particular, escribinos y armamos una propuesta a medida.
           </p>
         </div>
-        <div class="accordion" role="list">
-          <article class="accordion__item" role="listitem">
-            <h3>
-              <button
-                class="accordion__trigger"
-                type="button"
-                id="trigger-inmobiliario"
-                aria-expanded="false"
-                aria-controls="panel-inmobiliario"
-              >
-                <span class="accordion__title"><span class="accordion__emoji">🏡</span> Derecho inmobiliario</span>
-                <span class="accordion__icon" aria-hidden="true">+</span>
-              </button>
-            </h3>
-            <div class="accordion__content" id="panel-inmobiliario" role="region" aria-labelledby="trigger-inmobiliario" hidden>
-              <ul class="accordion__list">
-                <li>Boleto de compraventa y etapas previas a la escritura</li>
-                <li>Contratos de locación para vivienda, comerciales y temporarios</li>
-                <li>Asesoría integral en operaciones inmobiliarias</li>
-                <li>Trámites registrales y regularización de inmuebles</li>
-                <li>Fideicomisos: constitución, administración y seguimiento legal</li>
-              </ul>
-            </div>
-          </article>
-          <article class="accordion__item" role="listitem">
-            <h3>
-              <button
-                class="accordion__trigger"
-                type="button"
-                id="trigger-familia"
-                aria-expanded="false"
-                aria-controls="panel-familia"
-              >
-                <span class="accordion__title"><span class="accordion__emoji">👨‍👩‍👧</span> Derecho de familia</span>
-                <span class="accordion__icon" aria-hidden="true">+</span>
-              </button>
-            </h3>
-            <div class="accordion__content" id="panel-familia" role="region" aria-labelledby="trigger-familia" hidden>
-              <ul class="accordion__list">
-                <li>Sucesiones y planificación hereditaria</li>
-                <li>Divorcios de común acuerdo o contenciosos</li>
-                <li>Convenios de alimentos, tenencia y régimen de visitas</li>
-                <li>Procesos de adopción y filiación</li>
-                <li>Violencia familiar y medidas cautelares</li>
-              </ul>
-            </div>
-          </article>
-          <article class="accordion__item" role="listitem">
-            <h3>
-              <button
-                class="accordion__trigger"
-                type="button"
-                id="trigger-laboral"
-                aria-expanded="false"
-                aria-controls="panel-laboral"
-              >
-                <span class="accordion__title"><span class="accordion__emoji">💼</span> Derecho laboral</span>
-                <span class="accordion__icon" aria-hidden="true">+</span>
-              </button>
-            </h3>
-            <div class="accordion__content" id="panel-laboral" role="region" aria-labelledby="trigger-laboral" hidden>
-              <ul class="accordion__list">
-                <li>Asesoramiento a empleadores y trabajadores</li>
-                <li>Reclamos por despidos, indemnizaciones y accidentes laborales</li>
-                <li>Liquidaciones finales y cálculo de haberes</li>
-                <li>Negociaciones individuales y colectivas</li>
-                <li>Representación ante el Ministerio de Trabajo</li>
-              </ul>
-            </div>
-          </article>
-          <article class="accordion__item" role="listitem">
-            <h3>
-              <button
-                class="accordion__trigger"
-                type="button"
-                id="trigger-comercial"
-                aria-expanded="false"
-                aria-controls="panel-comercial"
-              >
-                <span class="accordion__title"><span class="accordion__emoji">📄</span> Derecho comercial y societario</span>
-                <span class="accordion__icon" aria-hidden="true">+</span>
-              </button>
-            </h3>
-            <div class="accordion__content" id="panel-comercial" role="region" aria-labelledby="trigger-comercial" hidden>
-              <ul class="accordion__list">
-                <li>Constitución de sociedades (SRL, SA, SAS)</li>
-                <li>Redacción de estatutos, contratos y actas societarias</li>
-                <li>Reestructuraciones y acuerdos entre socios</li>
-                <li>Asesoramiento en contratos comerciales y civiles</li>
-              </ul>
-            </div>
-          </article>
-          <article class="accordion__item" role="listitem">
-            <h3>
-              <button
-                class="accordion__trigger"
-                type="button"
-                id="trigger-civil"
-                aria-expanded="false"
-                aria-controls="panel-civil"
-              >
-                <span class="accordion__title"><span class="accordion__emoji">⚖️</span> Derecho civil</span>
-                <span class="accordion__icon" aria-hidden="true">+</span>
-              </button>
-            </h3>
-            <div class="accordion__content" id="panel-civil" role="region" aria-labelledby="trigger-civil" hidden>
-              <ul class="accordion__list">
-                <li>Redacción y revisión de contratos</li>
-                <li>Reclamos por daños y perjuicios</li>
-                <li>Cobro de deudas y ejecuciones</li>
-                <li>Defensa en juicios civiles</li>
-                <li>Acciones de amparo</li>
-              </ul>
-            </div>
-          </article>
-          <article class="accordion__item" role="listitem">
-            <h3>
-              <button
-                class="accordion__trigger"
-                type="button"
-                id="trigger-penal"
-                aria-expanded="false"
-                aria-controls="panel-penal"
-              >
-                <span class="accordion__title"><span class="accordion__emoji">🛡️</span> Derecho penal</span>
-                <span class="accordion__icon" aria-hidden="true">+</span>
-              </button>
-            </h3>
-            <div class="accordion__content" id="panel-penal" role="region" aria-labelledby="trigger-penal" hidden>
-              <ul class="accordion__list">
-                <li>Defensa en causas penales</li>
-                <li>Denuncias, querellas y asistencia a víctimas</li>
-                <li>Excarcelaciones y medidas cautelares</li>
-                <li>Estrategias preventivas y compliance penal</li>
-              </ul>
-            </div>
-          </article>
+        <div class="service-accordion" role="list">
+          <details class="service-accordion__item" open>
+            <summary>
+              <span class="service-accordion__title">🏡 Derecho inmobiliario</span>
+              <span class="service-accordion__icon" aria-hidden="true"></span>
+            </summary>
+            <ul>
+              <li>Boleto de compraventa y seguimiento de escrituración</li>
+              <li>Contratos de locación para vivienda, comerciales y temporarios</li>
+              <li>Due diligence y asesoría integral en operaciones inmobiliarias</li>
+              <li>Regularización dominial y trámites registrales</li>
+              <li>Constitución y administración legal de fideicomisos</li>
+            </ul>
+          </details>
+
+          <details class="service-accordion__item">
+            <summary>
+              <span class="service-accordion__title">👨‍👩‍👧 Derecho de familia</span>
+              <span class="service-accordion__icon" aria-hidden="true"></span>
+            </summary>
+            <ul>
+              <li>Divorcios de común acuerdo o contenciosos</li>
+              <li>Convenios de alimentos, cuidado personal y régimen de comunicación</li>
+              <li>Sucesiones y planificación hereditaria</li>
+              <li>Adopciones, filiaciones y uniones convivenciales</li>
+              <li>Acompañamiento integral ante situaciones de violencia familiar</li>
+            </ul>
+          </details>
+
+          <details class="service-accordion__item">
+            <summary>
+              <span class="service-accordion__title">💼 Derecho laboral</span>
+              <span class="service-accordion__icon" aria-hidden="true"></span>
+            </summary>
+            <ul>
+              <li>Asesoramiento a empleadores y trabajadores</li>
+              <li>Reclamos por despidos, accidentes laborales e indemnizaciones</li>
+              <li>Liquidaciones finales y cálculo de haberes</li>
+              <li>Negociaciones individuales y colectivas</li>
+              <li>Representación ante el Ministerio de Trabajo y auditorías</li>
+            </ul>
+          </details>
+
+          <details class="service-accordion__item">
+            <summary>
+              <span class="service-accordion__title">📄 Derecho comercial y societario</span>
+              <span class="service-accordion__icon" aria-hidden="true"></span>
+            </summary>
+            <ul>
+              <li>Constitución de sociedades (SRL, SA, SAS) y acuerdos societarios</li>
+              <li>Redacción de estatutos, actas y contratos comerciales</li>
+              <li>Due diligence y reorganizaciones empresariales</li>
+              <li>Asesoramiento en contratos civiles y comerciales</li>
+              <li>Gestión de cumplimiento normativo y gobierno corporativo</li>
+            </ul>
+          </details>
+
+          <details class="service-accordion__item">
+            <summary>
+              <span class="service-accordion__title">⚖️ Derecho civil</span>
+              <span class="service-accordion__icon" aria-hidden="true"></span>
+            </summary>
+            <ul>
+              <li>Redacción y revisión de contratos civiles</li>
+              <li>Reclamos por daños y perjuicios</li>
+              <li>Cobro de deudas y ejecuciones</li>
+              <li>Acciones de amparo y medidas cautelares</li>
+              <li>Resolución de conflictos extrajudiciales</li>
+            </ul>
+          </details>
+
+          <details class="service-accordion__item">
+            <summary>
+              <span class="service-accordion__title">🛡️ Derecho penal</span>
+              <span class="service-accordion__icon" aria-hidden="true"></span>
+            </summary>
+            <ul>
+              <li>Defensa en causas penales en todas las instancias</li>
+              <li>Presentación de denuncias y querellas</li>
+              <li>Asistencia a víctimas y medidas de protección</li>
+              <li>Excarcelaciones y estrategias cautelares</li>
+              <li>Programas de compliance y prevención del delito</li>
+            </ul>
+          </details>
         </div>
       </section>
 
       <section class="contact" id="contacto">
-        <div class="contact__intro">
-          <span class="contact__eyebrow">Agendemos una reunión</span>
+        <div class="section-heading">
+          <span class="section-heading__eyebrow">Agendemos una reunión</span>
           <h2>Contanos en qué podemos ayudarte</h2>
           <p>
-            Completá el formulario o elegí el medio que prefieras. Respondemos dentro de las 24
-            horas hábiles y coordinamos el seguimiento de tu consulta.
+            Elegí el medio que prefieras o completá el formulario. Respondemos dentro de las 24 horas
+            hábiles con los próximos pasos para tu consulta.
           </p>
         </div>
         <div class="contact__grid">
-          <div class="contact__card">
+          <article class="contact-card">
             <h3>Datos de contacto</h3>
-            <ul class="contact__list">
+            <ul>
               <li>
-                <span class="contact__label">Teléfono</span>
+                <span>Teléfono</span>
                 <a href="tel:+541123334455">+54 11 2333 4455</a>
               </li>
               <li>
-                <span class="contact__label">Email</span>
+                <span>Email</span>
                 <a href="mailto:hola@estudiomeraki.com">hola@estudiomeraki.com</a>
               </li>
               <li>
-                <span class="contact__label">Dirección</span>
+                <span>Dirección</span>
                 <address>
                   Av. Callao 1234, Piso 3 Oficina B<br />
                   Ciudad Autónoma de Buenos Aires
                 </address>
               </li>
               <li>
-                <span class="contact__label">Horarios</span>
+                <span>Horarios</span>
                 <p>Lunes a Viernes de 9 a 18 h</p>
               </li>
             </ul>
-          </div>
+            <div class="contact-card__cta">
+              <a class="button button--ghost" href="https://wa.me/5491122334455" target="_blank" rel="noopener">
+                Escribir por WhatsApp
+              </a>
+              <a class="button button--ghost" href="mailto:hola@estudiomeraki.com">Enviar correo</a>
+            </div>
+          </article>
 
           <form class="form" action="#" method="post">
             <h3>Enviá tu consulta</h3>
@@ -290,13 +253,13 @@
       </section>
     </main>
 
-    <footer class="footer">
+    <footer class="site-footer">
       <p>© <span id="year"></span> Estudio Meraki. Todos los derechos reservados.</p>
-      <nav class="footer__nav">
-        <a href="#sobre-nosotros">El estudio</a>
-        <a href="#asesoramiento">Servicios</a>
+      <nav aria-label="Navegación en el pie" class="site-footer__nav">
+        <a href="#inicio">Inicio</a>
+        <a href="#sobre-el-estudio">El estudio</a>
+        <a href="#servicios">Servicios</a>
         <a href="#contacto">Contacto</a>
-        <a href="https://wa.me/5491122334455" target="_blank" rel="noopener">WhatsApp</a>
       </nav>
     </footer>
 
@@ -305,22 +268,6 @@
       if (yearElement) {
         yearElement.textContent = new Date().getFullYear();
       }
-
-      const accordionTriggers = document.querySelectorAll(".accordion__trigger");
-      accordionTriggers.forEach((trigger) => {
-        const content = document.getElementById(trigger.getAttribute("aria-controls"));
-        const icon = trigger.querySelector(".accordion__icon");
-        trigger.addEventListener("click", () => {
-          const isExpanded = trigger.getAttribute("aria-expanded") === "true";
-          trigger.setAttribute("aria-expanded", String(!isExpanded));
-          if (content) {
-            content.hidden = isExpanded;
-          }
-          if (icon) {
-            icon.textContent = isExpanded ? "+" : "−";
-          }
-        });
-      });
     </script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,483 @@
+:root {
+  --color-primary: #3b4b9a;
+  --color-primary-dark: #2c3774;
+  --color-secondary: #f4ede2;
+  --color-accent: #f5c16f;
+  --color-text: #2d2a32;
+  --color-muted: #6a6872;
+  --font-heading: "Playfair Display", serif;
+  --font-body: "Work Sans", sans-serif;
+  --shadow-soft: 0 20px 40px rgba(25, 26, 35, 0.08);
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+  --max-width: 1100px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-body);
+  color: var(--color-text);
+  background: linear-gradient(180deg, #f9f6f2 0%, #ffffff 100%);
+  min-height: 100%;
+}
+
+a {
+  color: inherit;
+}
+
+a:hover,
+a:focus {
+  color: var(--color-primary);
+}
+
+.hero {
+  background: radial-gradient(circle at top left, rgba(59, 75, 154, 0.18), transparent 55%),
+    linear-gradient(120deg, rgba(244, 237, 226, 0.9), rgba(255, 255, 255, 0.8));
+  padding: 6rem 1.5rem 5.5rem;
+  display: flex;
+  justify-content: center;
+  text-align: center;
+}
+
+.hero__content {
+  max-width: 680px;
+}
+
+.hero__logo {
+  width: 110px;
+  height: auto;
+  margin-bottom: 1rem;
+}
+
+.hero__tagline {
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.75rem;
+  color: var(--color-primary-dark);
+  margin-bottom: 0.75rem;
+}
+
+.hero__title {
+  font-family: var(--font-heading);
+  font-size: clamp(2.5rem, 6vw, 3.75rem);
+  margin: 0.2rem 0 1rem;
+  color: var(--color-primary-dark);
+}
+
+.hero__description {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: var(--color-muted);
+  margin-bottom: 2rem;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  border: 2px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  background: #fff;
+  color: var(--color-primary-dark);
+  box-shadow: var(--shadow-soft);
+}
+
+.button:hover,
+.button:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(43, 57, 121, 0.18);
+}
+
+.button--primary {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.button--primary:hover,
+.button--primary:focus {
+  background: var(--color-primary-dark);
+}
+
+main {
+  padding: 0 1.5rem 5rem;
+}
+
+.about,
+.advisory,
+.contact {
+  max-width: var(--max-width);
+  margin: 0 auto 4.5rem;
+  background: #fff;
+  border-radius: var(--radius-lg);
+  padding: 3rem 3.5rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.about {
+  margin-top: -4.5rem;
+}
+
+.about__eyebrow,
+.advisory__eyebrow,
+.contact__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-primary-dark);
+  margin-bottom: 1rem;
+}
+
+.about__eyebrow::before,
+.advisory__eyebrow::before,
+.contact__eyebrow::before {
+  content: "";
+  width: 26px;
+  height: 1px;
+  background: currentColor;
+  opacity: 0.6;
+}
+
+.about__intro h2,
+.advisory__header h2,
+.contact__intro h2 {
+  font-family: var(--font-heading);
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin: 0 0 1rem;
+  color: var(--color-primary-dark);
+}
+
+.about__intro p,
+.advisory__header p,
+.contact__intro p {
+  margin: 0 0 2.5rem;
+  color: var(--color-muted);
+  line-height: 1.7;
+  max-width: 680px;
+}
+
+.about__grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.about__card {
+  background: linear-gradient(180deg, rgba(59, 75, 154, 0.08), rgba(244, 237, 226, 0.3));
+  border-radius: var(--radius-md);
+  padding: 1.8rem;
+  box-shadow: inset 0 0 0 1px rgba(59, 75, 154, 0.12);
+}
+
+.about__card h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1.2rem;
+  color: var(--color-primary-dark);
+}
+
+.about__card p {
+  margin: 0;
+  color: var(--color-muted);
+  line-height: 1.6;
+}
+
+.advisory {
+  position: relative;
+  background: linear-gradient(140deg, rgba(244, 237, 226, 0.65), #ffffff 60%);
+}
+
+.advisory__header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.advisory__header p {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.accordion {
+  display: grid;
+  gap: 1rem;
+}
+
+.accordion__item {
+  border-radius: var(--radius-md);
+  background: #fff;
+  box-shadow: inset 0 0 0 1px rgba(59, 75, 154, 0.12);
+  overflow: hidden;
+}
+
+.accordion__trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.4rem 1.8rem;
+  font: inherit;
+  font-weight: 600;
+  font-size: 1.05rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-primary-dark);
+  transition: background 0.2s ease;
+}
+
+.accordion__trigger:hover,
+.accordion__trigger:focus {
+  background: rgba(59, 75, 154, 0.08);
+  outline: none;
+}
+
+.accordion__title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.accordion__emoji {
+  font-size: 1.4rem;
+}
+
+.accordion__icon {
+  font-size: 1.6rem;
+  line-height: 1;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.accordion__content {
+  padding: 0 1.8rem 1.6rem;
+  color: var(--color-muted);
+}
+
+
+.accordion__list {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.65rem;
+  list-style: none;
+}
+
+.accordion__list li {
+  position: relative;
+  padding-left: 1.4rem;
+  line-height: 1.6;
+}
+
+.accordion__list li::before {
+  content: "•";
+  position: absolute;
+  left: 0;
+  top: 0.1rem;
+  color: var(--color-primary);
+}
+
+.contact {
+  background: #fff;
+}
+
+.contact__grid {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.contact__card {
+  background: var(--color-secondary);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.contact__card h3 {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.contact__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.contact__label {
+  display: block;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+  color: var(--color-primary-dark);
+  margin-bottom: 0.4rem;
+}
+
+.contact__list a {
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.contact__list address,
+.contact__list p {
+  margin: 0;
+  font-style: normal;
+  color: var(--color-muted);
+}
+
+.form {
+  background: #fff;
+  border-radius: var(--radius-md);
+  padding: 2.5rem;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.form h3 {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.form__field span {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.form__field input,
+.form__field select,
+.form__field textarea {
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(59, 75, 154, 0.18);
+  font: inherit;
+  background: rgba(59, 75, 154, 0.05);
+  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form__field input:focus,
+.form__field select:focus,
+.form__field textarea:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  background: #fff;
+  box-shadow: 0 0 0 4px rgba(59, 75, 154, 0.12);
+}
+
+.form__field--textarea textarea {
+  resize: vertical;
+  min-height: 140px;
+}
+
+.form__disclaimer {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.footer {
+  border-top: 1px solid rgba(59, 75, 154, 0.12);
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.footer__nav {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1.5rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.footer__nav a {
+  text-decoration: none;
+  font-weight: 500;
+  color: var(--color-primary-dark);
+}
+
+.footer__nav a:hover,
+.footer__nav a:focus {
+  text-decoration: underline;
+}
+
+@media (max-width: 720px) {
+  .about,
+  .advisory,
+  .contact {
+    padding: 2.5rem 1.75rem;
+  }
+
+  .about {
+    margin-top: -3rem;
+  }
+
+  .accordion__trigger {
+    padding: 1.2rem 1.4rem;
+    font-size: 1rem;
+  }
+
+  .accordion__content {
+    padding: 0 1.4rem 1.4rem;
+  }
+
+  .form {
+    padding: 2rem 1.5rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .hero {
+    padding: 4.5rem 1.25rem 3.5rem;
+  }
+
+  .hero__actions {
+    flex-direction: column;
+  }
+
+  .contact__card {
+    padding: 1.75rem;
+  }
+
+  .about {
+    margin-top: -2rem;
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,17 +1,17 @@
 :root {
-  --color-primary: #3b4b9a;
-  --color-primary-dark: #2c3774;
-  --color-secondary: #f4ede2;
-  --color-accent: #f5c16f;
-  --color-text: #2d2a32;
-  --color-muted: #6a6872;
-  --font-heading: "Playfair Display", serif;
-  --font-body: "Work Sans", sans-serif;
-  --shadow-soft: 0 20px 40px rgba(25, 26, 35, 0.08);
-  --radius-lg: 24px;
-  --radius-md: 16px;
+  --color-primary: #324694;
+  --color-primary-dark: #252f67;
+  --color-secondary: #f7f2ea;
+  --color-accent: #f3c372;
+  --color-text: #2b2933;
+  --color-muted: #6c6a75;
+  --shadow-soft: 0 25px 45px rgba(37, 41, 82, 0.12);
+  --radius-lg: 28px;
+  --radius-md: 18px;
   --radius-sm: 12px;
-  --max-width: 1100px;
+  --max-width: 1120px;
+  --font-display: "Playfair Display", serif;
+  --font-body: "Work Sans", sans-serif;
 }
 
 * {
@@ -24,7 +24,7 @@ body {
   padding: 0;
   font-family: var(--font-body);
   color: var(--color-text);
-  background: linear-gradient(180deg, #f9f6f2 0%, #ffffff 100%);
+  background: linear-gradient(180deg, #fdfbf8 0%, #ffffff 75%);
   min-height: 100%;
 }
 
@@ -37,327 +37,335 @@ a:focus {
   color: var(--color-primary);
 }
 
-.hero {
-  background: radial-gradient(circle at top left, rgba(59, 75, 154, 0.18), transparent 55%),
-    linear-gradient(120deg, rgba(244, 237, 226, 0.9), rgba(255, 255, 255, 0.8));
-  padding: 6rem 1.5rem 5.5rem;
+.site-header {
+  background: radial-gradient(circle at top left, rgba(50, 70, 148, 0.25), transparent 60%),
+    linear-gradient(135deg, rgba(247, 242, 234, 0.9), rgba(255, 255, 255, 0.95));
+  padding: 2rem clamp(1.25rem, 6vw, 4rem) 5rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.site-header::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 85% -10%, rgba(243, 195, 114, 0.25), transparent 45%);
+  pointer-events: none;
+}
+
+.site-header__inner {
   display: flex;
-  justify-content: center;
-  text-align: center;
-}
-
-.hero__content {
-  max-width: 680px;
-}
-
-.hero__logo {
-  width: 110px;
-  height: auto;
-  margin-bottom: 1rem;
-}
-
-.hero__tagline {
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.22em;
-  font-size: 0.75rem;
-  color: var(--color-primary-dark);
-  margin-bottom: 0.75rem;
-}
-
-.hero__title {
-  font-family: var(--font-heading);
-  font-size: clamp(2.5rem, 6vw, 3.75rem);
-  margin: 0.2rem 0 1rem;
-  color: var(--color-primary-dark);
-}
-
-.hero__description {
-  font-size: 1.05rem;
-  line-height: 1.7;
-  color: var(--color-muted);
-  margin-bottom: 2rem;
-}
-
-.hero__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  justify-content: center;
-}
-
-.button {
-  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  padding: 0.85rem 1.75rem;
-  border-radius: 999px;
-  font-weight: 600;
+  justify-content: space-between;
+  gap: 2rem;
+  flex-wrap: wrap;
+  position: relative;
+  z-index: 1;
+}
+
+.brand {
+  width: clamp(84px, 9vw, 110px);
+  height: auto;
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.75rem, 3vw, 2rem);
+  flex-wrap: wrap;
+  font-size: 0.95rem;
+}
+
+.site-nav a {
   text-decoration: none;
-  border: 2px solid transparent;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-  background: #fff;
-  color: var(--color-primary-dark);
-  box-shadow: var(--shadow-soft);
+  font-weight: 500;
+  padding: 0.45rem 0.15rem;
 }
 
-.button:hover,
-.button:focus {
-  transform: translateY(-2px);
-  box-shadow: 0 12px 24px rgba(43, 57, 121, 0.18);
+.site-nav__cta {
+  border: 2px solid rgba(50, 70, 148, 0.25);
+  border-radius: 999px;
+  padding: 0.6rem 1.3rem;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
 }
 
-.button--primary {
+.site-nav__cta:hover,
+.site-nav__cta:focus {
+  border-color: rgba(50, 70, 148, 0.7);
   background: var(--color-primary);
   color: #fff;
 }
 
-.button--primary:hover,
-.button--primary:focus {
-  background: var(--color-primary-dark);
+.hero {
+  max-width: 720px;
+  margin: clamp(2.5rem, 5vw, 4rem) auto 0;
+  text-align: center;
+  position: relative;
+  z-index: 1;
 }
 
-main {
-  padding: 0 1.5rem 5rem;
-}
-
-.about,
-.advisory,
-.contact {
-  max-width: var(--max-width);
-  margin: 0 auto 4.5rem;
-  background: #fff;
-  border-radius: var(--radius-lg);
-  padding: 3rem 3.5rem;
-  box-shadow: var(--shadow-soft);
-}
-
-.about {
-  margin-top: -4.5rem;
-}
-
-.about__eyebrow,
-.advisory__eyebrow,
-.contact__eyebrow {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  text-transform: uppercase;
-  letter-spacing: 0.2em;
-  font-size: 0.75rem;
+.hero__kicker {
   font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 0.75rem;
   color: var(--color-primary-dark);
   margin-bottom: 1rem;
 }
 
-.about__eyebrow::before,
-.advisory__eyebrow::before,
-.contact__eyebrow::before {
+.hero__title {
+  font-family: var(--font-display);
+  font-size: clamp(2.7rem, 8vw, 4rem);
+  margin: 0.35rem 0 1.2rem;
+  color: var(--color-primary-dark);
+}
+
+.hero__lead {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: var(--color-muted);
+  margin: 0 auto 2.5rem;
+}
+
+.hero__actions {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+main {
+  padding: 0 clamp(1.25rem, 6vw, 4rem) 5rem;
+}
+
+.section-heading {
+  max-width: 680px;
+  display: grid;
+  gap: 1.25rem;
+  margin-bottom: 3rem;
+}
+
+.section-heading--center {
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
+}
+
+.section-heading__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  color: var(--color-primary-dark);
+}
+
+.section-heading__eyebrow::before {
   content: "";
   width: 26px;
   height: 1px;
   background: currentColor;
-  opacity: 0.6;
+  opacity: 0.65;
 }
 
-.about__intro h2,
-.advisory__header h2,
-.contact__intro h2 {
-  font-family: var(--font-heading);
-  font-size: clamp(2rem, 4vw, 2.8rem);
-  margin: 0 0 1rem;
+.section-heading h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(2.1rem, 5vw, 3rem);
   color: var(--color-primary-dark);
 }
 
-.about__intro p,
-.advisory__header p,
-.contact__intro p {
-  margin: 0 0 2.5rem;
-  color: var(--color-muted);
+.section-heading p {
+  margin: 0;
   line-height: 1.7;
-  max-width: 680px;
+  color: var(--color-muted);
+}
+
+.about,
+.services,
+.contact {
+  max-width: var(--max-width);
+  margin: 0 auto 4.75rem;
+  background: #fff;
+  border-radius: var(--radius-lg);
+  padding: clamp(2.5rem, 5vw, 3.5rem);
+  box-shadow: var(--shadow-soft);
+  position: relative;
+  z-index: 1;
+}
+
+.about {
+  margin-top: -4rem;
 }
 
 .about__grid {
   display: grid;
   gap: 1.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
 }
 
-.about__card {
-  background: linear-gradient(180deg, rgba(59, 75, 154, 0.08), rgba(244, 237, 226, 0.3));
+.about-card {
+  background: linear-gradient(150deg, rgba(50, 70, 148, 0.12), rgba(247, 242, 234, 0.6));
   border-radius: var(--radius-md);
-  padding: 1.8rem;
-  box-shadow: inset 0 0 0 1px rgba(59, 75, 154, 0.12);
+  padding: 2rem;
+  box-shadow: inset 0 0 0 1px rgba(50, 70, 148, 0.15);
 }
 
-.about__card h3 {
-  margin: 0 0 0.75rem;
-  font-size: 1.2rem;
+.about-card h3 {
+  margin: 0 0 0.9rem;
+  font-size: 1.25rem;
   color: var(--color-primary-dark);
 }
 
-.about__card p {
+.about-card p {
   margin: 0;
+  line-height: 1.65;
   color: var(--color-muted);
-  line-height: 1.6;
 }
 
-.advisory {
-  position: relative;
-  background: linear-gradient(140deg, rgba(244, 237, 226, 0.65), #ffffff 60%);
-}
-
-.advisory__header {
-  text-align: center;
-  margin-bottom: 2.5rem;
-}
-
-.advisory__header p {
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.accordion {
+.service-accordion {
   display: grid;
   gap: 1rem;
 }
 
-.accordion__item {
+.service-accordion__item {
   border-radius: var(--radius-md);
-  background: #fff;
-  box-shadow: inset 0 0 0 1px rgba(59, 75, 154, 0.12);
-  overflow: hidden;
+  border: 1px solid rgba(50, 70, 148, 0.18);
+  padding: 0;
+  background: rgba(50, 70, 148, 0.04);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.accordion__trigger {
-  width: 100%;
+.service-accordion__item[open] {
+  background: #fff;
+  border-color: rgba(50, 70, 148, 0.35);
+  box-shadow: 0 15px 30px rgba(50, 70, 148, 0.08);
+}
+
+.service-accordion__item summary {
+  list-style: none;
+  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1.5rem;
-  padding: 1.4rem 1.8rem;
-  font: inherit;
+  gap: 1rem;
+  padding: 1.35rem 1.85rem;
   font-weight: 600;
-  font-size: 1.05rem;
-  background: transparent;
-  border: none;
-  cursor: pointer;
   color: var(--color-primary-dark);
-  transition: background 0.2s ease;
 }
 
-.accordion__trigger:hover,
-.accordion__trigger:focus {
-  background: rgba(59, 75, 154, 0.08);
-  outline: none;
+.service-accordion__item summary::-webkit-details-marker {
+  display: none;
 }
 
-.accordion__title {
-  display: flex;
+.service-accordion__title {
+  display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.8rem;
+  font-size: 1.05rem;
 }
 
-.accordion__emoji {
-  font-size: 1.4rem;
-}
-
-.accordion__icon {
+.service-accordion__icon::before {
+  content: "+";
+  display: inline-block;
   font-size: 1.6rem;
-  line-height: 1;
   font-weight: 600;
+  line-height: 1;
   color: var(--color-primary);
+  transition: transform 0.2s ease;
 }
 
-.accordion__content {
-  padding: 0 1.8rem 1.6rem;
-  color: var(--color-muted);
+.service-accordion__item[open] .service-accordion__icon::before {
+  content: "−";
 }
 
-
-.accordion__list {
+.service-accordion__item ul {
   margin: 0;
-  padding: 0;
+  padding: 0 1.85rem 1.75rem 2.4rem;
   display: grid;
   gap: 0.65rem;
   list-style: none;
+  color: var(--color-muted);
 }
 
-.accordion__list li {
+.service-accordion__item li {
   position: relative;
-  padding-left: 1.4rem;
   line-height: 1.6;
+  padding-left: 1rem;
 }
 
-.accordion__list li::before {
+.service-accordion__item li::before {
   content: "•";
   position: absolute;
   left: 0;
-  top: 0.1rem;
+  top: 0;
   color: var(--color-primary);
-}
-
-.contact {
-  background: #fff;
+  font-weight: 600;
 }
 
 .contact__grid {
   display: grid;
-  gap: 2.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(2rem, 5vw, 3rem);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
-.contact__card {
+.contact-card {
   background: var(--color-secondary);
   border-radius: var(--radius-md);
-  padding: 2rem;
+  padding: clamp(2rem, 5vw, 2.5rem);
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
-.contact__card h3 {
+.contact-card h3 {
   margin: 0;
   font-size: 1.35rem;
   font-weight: 600;
 }
 
-.contact__list {
-  list-style: none;
+.contact-card ul {
   margin: 0;
   padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
+  list-style: none;
+  display: grid;
+  gap: 1.4rem;
 }
 
-.contact__label {
+.contact-card li span {
   display: block;
-  font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 0.8rem;
+  font-weight: 600;
   color: var(--color-primary-dark);
-  margin-bottom: 0.4rem;
+  margin-bottom: 0.35rem;
 }
 
-.contact__list a {
-  font-weight: 500;
+.contact-card a {
   text-decoration: none;
+  font-weight: 500;
 }
 
-.contact__list address,
-.contact__list p {
+.contact-card address,
+.contact-card p {
   margin: 0;
-  font-style: normal;
   color: var(--color-muted);
+  font-style: normal;
+}
+
+.contact-card__cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
 
 .form {
   background: #fff;
   border-radius: var(--radius-md);
-  padding: 2.5rem;
+  padding: clamp(2.2rem, 5vw, 2.8rem);
   box-shadow: var(--shadow-soft);
   display: grid;
   gap: 1.5rem;
@@ -367,12 +375,12 @@ main {
   margin: 0;
   font-size: 1.35rem;
   font-weight: 600;
+  color: var(--color-primary-dark);
 }
 
 .form__field {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  display: grid;
+  gap: 0.55rem;
   font-size: 0.95rem;
 }
 
@@ -386,10 +394,10 @@ main {
 .form__field textarea {
   padding: 0.85rem 1rem;
   border-radius: var(--radius-sm);
-  border: 1px solid rgba(59, 75, 154, 0.18);
+  border: 1px solid rgba(50, 70, 148, 0.2);
+  background: rgba(50, 70, 148, 0.05);
   font: inherit;
-  background: rgba(59, 75, 154, 0.05);
-  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .form__field input:focus,
@@ -398,7 +406,7 @@ main {
   outline: none;
   border-color: var(--color-primary);
   background: #fff;
-  box-shadow: 0 0 0 4px rgba(59, 75, 154, 0.12);
+  box-shadow: 0 0 0 4px rgba(50, 70, 148, 0.12);
 }
 
 .form__field--textarea textarea {
@@ -407,77 +415,113 @@ main {
 }
 
 .form__disclaimer {
+  margin: 0;
   font-size: 0.85rem;
   color: var(--color-muted);
-  margin: 0;
 }
 
-.footer {
-  border-top: 1px solid rgba(59, 75, 154, 0.12);
-  padding: 2.5rem 1.5rem;
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+  background: #fff;
+  color: var(--color-primary-dark);
+  box-shadow: var(--shadow-soft);
+}
+
+.button:hover,
+.button:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 24px rgba(37, 41, 82, 0.18);
+}
+
+.button--primary {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.button--primary:hover,
+.button--primary:focus {
+  background: var(--color-primary-dark);
+}
+
+.button--ghost {
+  background: transparent;
+  border-color: rgba(50, 70, 148, 0.25);
+}
+
+.button--ghost:hover,
+.button--ghost:focus {
+  border-color: rgba(50, 70, 148, 0.6);
+  color: var(--color-primary-dark);
+}
+
+.site-footer {
+  padding: 3rem clamp(1.5rem, 6vw, 3.5rem);
   text-align: center;
   color: var(--color-muted);
   font-size: 0.95rem;
 }
 
-.footer__nav {
-  margin-top: 1rem;
+.site-footer__nav {
+  margin-top: 1.1rem;
   display: flex;
-  gap: 1.5rem;
   justify-content: center;
   flex-wrap: wrap;
+  gap: 1.5rem;
 }
 
-.footer__nav a {
+.site-footer__nav a {
   text-decoration: none;
   font-weight: 500;
   color: var(--color-primary-dark);
 }
 
-.footer__nav a:hover,
-.footer__nav a:focus {
+.site-footer__nav a:hover,
+.site-footer__nav a:focus {
   text-decoration: underline;
 }
 
-@media (max-width: 720px) {
-  .about,
-  .advisory,
-  .contact {
-    padding: 2.5rem 1.75rem;
+@media (max-width: 900px) {
+  .site-header__inner {
+    justify-content: center;
+  }
+
+  .site-nav {
+    justify-content: center;
   }
 
   .about {
     margin-top: -3rem;
   }
-
-  .accordion__trigger {
-    padding: 1.2rem 1.4rem;
-    font-size: 1rem;
-  }
-
-  .accordion__content {
-    padding: 0 1.4rem 1.4rem;
-  }
-
-  .form {
-    padding: 2rem 1.5rem;
-  }
 }
 
-@media (max-width: 520px) {
+@media (max-width: 600px) {
+  .site-header {
+    padding-bottom: 4rem;
+  }
+
   .hero {
-    padding: 4.5rem 1.25rem 3.5rem;
+    margin-top: 2.5rem;
   }
 
   .hero__actions {
     flex-direction: column;
   }
 
-  .contact__card {
-    padding: 1.75rem;
+  .site-nav {
+    flex-direction: column;
   }
 
-  .about {
-    margin-top: -2rem;
+  .contact-card__cta {
+    flex-direction: column;
   }
 }


### PR DESCRIPTION
## Summary
- reorganize the landing page so the presentation appears first with updated hero actions and a new "Sobre el estudio" section
- add accessible accordion menus for each área de asesoramiento with detailed items drawn from the provided references
- refresh the contact section placement and styling to sit after the services and align select options with the new categories

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d33db2e4d88332a893e8a4cce0ab9d