### PR TITLE
Fix chatbot message alignment and bubble width

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -327,11 +327,13 @@ main {
   box-shadow: inset 0 0 0 1px rgba(50, 70, 148, 0.12);
 }
 
+
 .chatbot__messages {
   background: #fff;
   border-radius: var(--radius-md);
   padding: 1.25rem;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 0.85rem;
   max-height: 340px;
   overflow-y: auto;
@@ -345,6 +347,8 @@ main {
   font-size: 0.95rem;
   position: relative;
   box-shadow: 0 10px 20px rgba(50, 70, 148, 0.08);
+  max-width: min(75ch, 100%);
+  align-self: flex-start;
 }
 
 .chatbot__bubble p {
@@ -362,6 +366,7 @@ main {
   background: var(--color-primary);
   color: #fff;
   border-bottom-right-radius: 6px;
+  align-self: flex-end;
 }
 
 .chatbot__bubble time {


### PR DESCRIPTION
## Summary
- switch the chatbot message container to a flex column layout so user bubbles can align to the right
- limit bubble width and align the user reply bubble to the container's edge for a tidier conversation look

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d36010b1f883329ed995b6ddc72227