### PR TITLE
Add skyscraper video background to hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,19 @@
   </head>
   <body>
     <header class="site-header" id="inicio">
+      <div class="hero-media" aria-hidden="true">
+        <video
+          class="hero-media__video"
+          autoplay
+          muted
+          loop
+          playsinline
+          poster="https://images.pexels.com/photos/586744/pexels-photo-586744.jpeg?auto=compress&cs=tinysrgb&w=1920"
+        >
+          <source src="https://cdn.coverr.co/videos/coverr-urban-skyscrapers-8409/1080p.mp4" type="video/mp4" />
+          Tu navegador no soporta video HTML5.
+        </video>
+      </div>
       <div class="site-header__inner">
         <img src="assets/logo-meraki.svg" alt="Logotipo Estudio Meraki" class="brand" />
         <nav class="site-nav" aria-label="Navegación principal">

--- a/styles.css
+++ b/styles.css
@@ -50,19 +50,42 @@ a:focus {
 }
 
 .site-header {
-  background: radial-gradient(circle at top left, rgba(50, 70, 148, 0.25), transparent 60%),
-    linear-gradient(135deg, rgba(247, 242, 234, 0.9), rgba(255, 255, 255, 0.95));
+  background: #0f172f;
+  color: #fff;
   padding: 2rem clamp(1.25rem, 6vw, 4rem) 5rem;
   position: relative;
   overflow: hidden;
 }
 
+.site-header::before,
 .site-header::after {
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 85% -10%, rgba(243, 195, 114, 0.25), transparent 45%);
   pointer-events: none;
+  z-index: 1;
+}
+
+.site-header::before {
+  background: linear-gradient(115deg, rgba(11, 18, 36, 0.82), rgba(17, 33, 74, 0.55));
+}
+
+.site-header::after {
+  background: radial-gradient(circle at 85% -10%, rgba(243, 195, 114, 0.25), transparent 45%);
+}
+
+.hero-media {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  z-index: 0;
+}
+
+.hero-media__video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(105%);
 }
 
 .site-header__inner {
@@ -72,7 +95,7 @@ a:focus {
   gap: 2rem;
   flex-wrap: wrap;
   position: relative;
-  z-index: 1;
+  z-index: 2;
 }
 
 .brand {
@@ -92,10 +115,23 @@ a:focus {
   text-decoration: none;
   font-weight: 500;
   padding: 0.45rem 0.15rem;
+  color: inherit;
+  opacity: 0.9;
+  transition: opacity 0.2s ease;
+}
+
+.site-nav a:hover,
+.site-nav a:focus {
+  opacity: 1;
+}
+
+.site-header a:hover,
+.site-header a:focus {
+  color: #fff;
 }
 
 .site-nav__cta {
-  border: 2px solid rgba(50, 70, 148, 0.25);
+  border: 2px solid rgba(255, 255, 255, 0.45);
   border-radius: 999px;
   padding: 0.6rem 1.3rem;
   transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
@@ -103,8 +139,8 @@ a:focus {
 
 .site-nav__cta:hover,
 .site-nav__cta:focus {
-  border-color: rgba(50, 70, 148, 0.7);
-  background: var(--color-primary);
+  border-color: rgba(255, 255, 255, 0.85);
+  background: rgba(255, 255, 255, 0.15);
   color: #fff;
 }
 
@@ -113,7 +149,7 @@ a:focus {
   margin: clamp(2.5rem, 5vw, 4rem) auto 0;
   text-align: center;
   position: relative;
-  z-index: 1;
+  z-index: 2;
 }
 
 .hero__kicker {
@@ -121,7 +157,7 @@ a:focus {
   text-transform: uppercase;
   letter-spacing: 0.24em;
   font-size: 0.75rem;
-  color: var(--color-primary-dark);
+  color: rgba(255, 255, 255, 0.75);
   margin-bottom: 1rem;
 }
 
@@ -129,13 +165,13 @@ a:focus {
   font-family: var(--font-display);
   font-size: clamp(2.7rem, 8vw, 4rem);
   margin: 0.35rem 0 1.2rem;
-  color: var(--color-primary-dark);
+  color: #fff;
 }
 
 .hero__lead {
   font-size: 1.05rem;
   line-height: 1.7;
-  color: var(--color-muted);
+  color: rgba(255, 255, 255, 0.85);
   margin: 0 auto 2.5rem;
 }
 


### PR DESCRIPTION
## Summary
- embed a looping skyscraper video in the hero header as a full-bleed background
- layer gradient overlays and adjust navigation colors for legible content over the video
- update hero typography colors to contrast against the new darkened backdrop

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3648414708332a2246907439652a5