### PR TITLE
Switch hero background to provided skyscraper footage

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,12 @@
   </head>
   <body>
     <header class="site-header" id="inicio">
+      <div class="hero-media" aria-hidden="true">
+        <video class="hero-media__video" autoplay muted loop playsinline>
+          <source src="assets/VideoRascacielos.mp4" type="video/mp4" />
+          Tu navegador no soporta video HTML5.
+        </video>
+      </div>
       <div class="site-header__inner">
         <img src="assets/logo-meraki.svg" alt="Logotipo Estudio Meraki" class="brand" />
         <nav class="site-nav" aria-label="Navegación principal">

--- a/styles.css
+++ b/styles.css
@@ -55,14 +55,46 @@ a:focus {
   padding: 2rem clamp(1.25rem, 6vw, 4rem) 5rem;
   position: relative;
   overflow: hidden;
+  color: var(--color-text);
 }
 
+.site-header::before,
 .site-header::after {
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 85% -10%, rgba(243, 195, 114, 0.25), transparent 45%);
   pointer-events: none;
+}
+
+.site-header::before {
+  background: linear-gradient(140deg, rgba(247, 242, 234, 0.9), rgba(255, 255, 255, 0.88));
+  z-index: 1;
+}
+
+.site-header::after {
+  background: radial-gradient(circle at 85% -10%, rgba(243, 195, 114, 0.25), transparent 45%);
+  z-index: 2;
+}
+
+.hero-media {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+  background: #0f172a;
+}
+
+.hero-media__video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(108%) brightness(0.95);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-media__video {
+    display: none;
+  }
 }
 
 .site-header__inner {
@@ -72,7 +104,7 @@ a:focus {
   gap: 2rem;
   flex-wrap: wrap;
   position: relative;
-  z-index: 1;
+  z-index: 3;
 }
 
 .brand {
@@ -113,7 +145,7 @@ a:focus {
   margin: clamp(2.5rem, 5vw, 4rem) auto 0;
   text-align: center;
   position: relative;
-  z-index: 1;
+  z-index: 3;
 }
 
 .hero__kicker {


### PR DESCRIPTION
## Summary
- embed the provided `assets/VideoRascacielos.mp4` as the hero background video with existing markup
- restore the original light color styling for the hero while layering gentle overlays for readability above the footage
- hide the background video for users who prefer reduced motion to keep the section accessible

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3648414708332a2246907439652a5