### PR TITLE
Configurar envío del formulario de contacto

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,7 +258,12 @@
             </div>
           </article>
 
-          <form class="form" action="#" method="post">
+          <form
+            class="form"
+            id="contact-form"
+            action="https://formsubmit.co/ejcmeraki@gmail.com"
+            method="post"
+          >
             <h3>Enviá tu consulta</h3>
             <label class="form__field">
               <span>Nombre completo</span>
@@ -289,7 +294,10 @@
               <span>Contanos más detalles</span>
               <textarea name="mensaje" rows="4" placeholder="Describí tu consulta"></textarea>
             </label>
+            <input type="hidden" name="_subject" value="Nueva consulta desde el sitio web" />
+            <input type="hidden" name="_captcha" value="false" />
             <button type="submit" class="button button--primary">Enviar consulta</button>
+            <p class="form__status" id="contact-form-status" aria-live="polite"></p>
             <p class="form__disclaimer">
               Al enviar tus datos aceptás ser contactado/a por un representante del Estudio Meraki.
             </p>
@@ -515,6 +523,71 @@
           "bot",
           "Hola, soy el asistente virtual del Estudio Meraki. Contame qué tipo de consulta tenés y te orientaré."
         );
+      }
+
+      const contactForm = document.getElementById("contact-form");
+      const contactFormStatus = document.getElementById("contact-form-status");
+
+      function setContactStatus(message, type) {
+        if (!contactFormStatus) return;
+        contactFormStatus.textContent = message;
+        contactFormStatus.classList.remove("form__status--success", "form__status--error");
+        if (type) {
+          contactFormStatus.classList.add(`form__status--${type}`);
+        }
+      }
+
+      async function handleContactFormSubmit(event) {
+        if (!contactForm) return;
+        event.preventDefault();
+
+        const submitButton = contactForm.querySelector('button[type="submit"]');
+        const originalButtonText = submitButton ? submitButton.textContent : "";
+
+        if (submitButton) {
+          submitButton.disabled = true;
+          submitButton.textContent = "Enviando...";
+        }
+
+        setContactStatus("Enviando tu consulta...", "");
+
+        try {
+          const formData = new FormData(contactForm);
+          const response = await fetch("https://formsubmit.co/ajax/ejcmeraki@gmail.com", {
+            method: "POST",
+            headers: { Accept: "application/json" },
+            body: formData,
+          });
+
+          if (!response.ok) {
+            const data = await response.json().catch(() => null);
+            const errorMessage =
+              (data && (data.message || data.error)) ||
+              "No pudimos enviar el formulario en este momento. Escribinos a ejcmeraki@gmail.com o por WhatsApp.";
+            setContactStatus(errorMessage, "error");
+            return;
+          }
+
+          setContactStatus(
+            "¡Gracias! Recibimos tu consulta y te contactaremos dentro de las próximas 24 horas hábiles.",
+            "success"
+          );
+          contactForm.reset();
+        } catch (error) {
+          setContactStatus(
+            "Ocurrió un inconveniente al enviar tu consulta. Por favor escribinos a ejcmeraki@gmail.com o por WhatsApp.",
+            "error"
+          );
+        } finally {
+          if (submitButton) {
+            submitButton.disabled = false;
+            submitButton.textContent = originalButtonText || "Enviar consulta";
+          }
+        }
+      }
+
+      if (contactForm && window.fetch) {
+        contactForm.addEventListener("submit", handleContactFormSubmit);
       }
     </script>
   </body>

--- a/styles.css
+++ b/styles.css
@@ -630,6 +630,21 @@ main {
   min-height: 140px;
 }
 
+.form__status {
+  margin: -0.75rem 0 0;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  min-height: 1.35rem;
+}
+
+.form__status--success {
+  color: #1f7a4d;
+}
+
+.form__status--error {
+  color: #b32323;
+}
+
 .form__disclaimer {
   margin: 0;
   font-size: 0.85rem;


### PR DESCRIPTION
## Summary
- conectar el formulario de contacto con FormSubmit para enviar las consultas al equipo
- agregar lógica en el frontend para mostrar estados de envío, éxito y error sin abandonar la página
- estilizar los mensajes de estado del formulario para mantener la consistencia visual

## Testing
- no se ejecutaron pruebas (sitio estático)


------
https://chatgpt.com/codex/tasks/task_e_68d3694fa3c8833285609d08607a34ac