### PR TITLE
Organize services by area and expand chatbot guidance

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,90 +92,158 @@
             un caso particular, escribinos y armamos una propuesta a medida.
           </p>
         </div>
-        <div class="service-accordion" role="list">
-          <details class="service-accordion__item" open>
-            <summary>
-              <span class="service-accordion__title">🏡 Derecho inmobiliario</span>
-              <span class="service-accordion__icon" aria-hidden="true"></span>
-            </summary>
-            <ul>
-              <li>Boleto de compraventa y seguimiento de escrituración</li>
-              <li>Contratos de locación para vivienda, comerciales y temporarios</li>
-              <li>Due diligence y asesoría integral en operaciones inmobiliarias</li>
-              <li>Regularización dominial y trámites registrales</li>
-              <li>Constitución y administración legal de fideicomisos</li>
-            </ul>
-          </details>
+        <div class="services__groups">
+          <div class="services__group">
+            <h3 class="services__group-title">Servicios legales</h3>
+            <div class="service-accordion" role="list">
+              <details class="service-accordion__item" open>
+                <summary>
+                  <span class="service-accordion__title">🏡 Derecho inmobiliario</span>
+                  <span class="service-accordion__icon" aria-hidden="true"></span>
+                </summary>
+                <ul>
+                  <li>Boleto de compraventa y seguimiento de escrituración</li>
+                  <li>Contratos de locación para vivienda, comerciales y temporarios</li>
+                  <li>Due diligence y asesoría integral en operaciones inmobiliarias</li>
+                  <li>Regularización dominial y trámites registrales</li>
+                  <li>Constitución y administración legal de fideicomisos</li>
+                </ul>
+              </details>
 
-          <details class="service-accordion__item">
-            <summary>
-              <span class="service-accordion__title">👨‍👩‍👧 Derecho de familia</span>
-              <span class="service-accordion__icon" aria-hidden="true"></span>
-            </summary>
-            <ul>
-              <li>Divorcios de común acuerdo o contenciosos</li>
-              <li>Convenios de alimentos, cuidado personal y régimen de comunicación</li>
-              <li>Sucesiones y planificación hereditaria</li>
-              <li>Adopciones, filiaciones y uniones convivenciales</li>
-              <li>Acompañamiento integral ante situaciones de violencia familiar</li>
-            </ul>
-          </details>
+              <details class="service-accordion__item">
+                <summary>
+                  <span class="service-accordion__title">👨‍👩‍👧 Derecho de familia</span>
+                  <span class="service-accordion__icon" aria-hidden="true"></span>
+                </summary>
+                <ul>
+                  <li>Divorcios de común acuerdo o contenciosos</li>
+                  <li>Convenios de alimentos, cuidado personal y régimen de comunicación</li>
+                  <li>Sucesiones y planificación hereditaria</li>
+                  <li>Adopciones, filiaciones y uniones convivenciales</li>
+                  <li>Acompañamiento integral ante situaciones de violencia familiar</li>
+                </ul>
+              </details>
 
-          <details class="service-accordion__item">
-            <summary>
-              <span class="service-accordion__title">💼 Derecho laboral</span>
-              <span class="service-accordion__icon" aria-hidden="true"></span>
-            </summary>
-            <ul>
-              <li>Asesoramiento a empleadores y trabajadores</li>
-              <li>Reclamos por despidos, accidentes laborales e indemnizaciones</li>
-              <li>Liquidaciones finales y cálculo de haberes</li>
-              <li>Negociaciones individuales y colectivas</li>
-              <li>Representación ante el Ministerio de Trabajo y auditorías</li>
-            </ul>
-          </details>
+              <details class="service-accordion__item">
+                <summary>
+                  <span class="service-accordion__title">💼 Derecho laboral</span>
+                  <span class="service-accordion__icon" aria-hidden="true"></span>
+                </summary>
+                <ul>
+                  <li>Asesoramiento a empleadores y trabajadores</li>
+                  <li>Reclamos por despidos, accidentes laborales e indemnizaciones</li>
+                  <li>Liquidaciones finales y cálculo de haberes</li>
+                  <li>Negociaciones individuales y colectivas</li>
+                  <li>Representación ante el Ministerio de Trabajo y auditorías</li>
+                </ul>
+              </details>
 
-          <details class="service-accordion__item">
-            <summary>
-              <span class="service-accordion__title">📄 Derecho comercial y societario</span>
-              <span class="service-accordion__icon" aria-hidden="true"></span>
-            </summary>
-            <ul>
-              <li>Constitución de sociedades (SRL, SA, SAS) y acuerdos societarios</li>
-              <li>Redacción de estatutos, actas y contratos comerciales</li>
-              <li>Due diligence y reorganizaciones empresariales</li>
-              <li>Asesoramiento en contratos civiles y comerciales</li>
-              <li>Gestión de cumplimiento normativo y gobierno corporativo</li>
-            </ul>
-          </details>
+              <details class="service-accordion__item">
+                <summary>
+                  <span class="service-accordion__title">📄 Derecho comercial y societario</span>
+                  <span class="service-accordion__icon" aria-hidden="true"></span>
+                </summary>
+                <ul>
+                  <li>Constitución de sociedades (SRL, SA, SAS) y acuerdos societarios</li>
+                  <li>Redacción de estatutos, actas y contratos comerciales</li>
+                  <li>Due diligence y reorganizaciones empresariales</li>
+                  <li>Asesoramiento en contratos civiles y comerciales</li>
+                  <li>Gestión de cumplimiento normativo y gobierno corporativo</li>
+                </ul>
+              </details>
 
-          <details class="service-accordion__item">
-            <summary>
-              <span class="service-accordion__title">⚖️ Derecho civil</span>
-              <span class="service-accordion__icon" aria-hidden="true"></span>
-            </summary>
-            <ul>
-              <li>Redacción y revisión de contratos civiles</li>
-              <li>Reclamos por daños y perjuicios</li>
-              <li>Cobro de deudas y ejecuciones</li>
-              <li>Acciones de amparo y medidas cautelares</li>
-              <li>Resolución de conflictos extrajudiciales</li>
-            </ul>
-          </details>
+              <details class="service-accordion__item">
+                <summary>
+                  <span class="service-accordion__title">⚖️ Derecho civil</span>
+                  <span class="service-accordion__icon" aria-hidden="true"></span>
+                </summary>
+                <ul>
+                  <li>Redacción y revisión de contratos civiles</li>
+                  <li>Reclamos por daños y perjuicios</li>
+                  <li>Cobro de deudas y ejecuciones</li>
+                  <li>Acciones de amparo y medidas cautelares</li>
+                  <li>Resolución de conflictos extrajudiciales</li>
+                </ul>
+              </details>
 
-          <details class="service-accordion__item">
-            <summary>
-              <span class="service-accordion__title">🛡️ Derecho penal</span>
-              <span class="service-accordion__icon" aria-hidden="true"></span>
-            </summary>
-            <ul>
-              <li>Defensa en causas penales en todas las instancias</li>
-              <li>Presentación de denuncias y querellas</li>
-              <li>Asistencia a víctimas y medidas de protección</li>
-              <li>Excarcelaciones y estrategias cautelares</li>
-              <li>Programas de compliance y prevención del delito</li>
-            </ul>
-          </details>
+              <details class="service-accordion__item">
+                <summary>
+                  <span class="service-accordion__title">🛡️ Derecho penal</span>
+                  <span class="service-accordion__icon" aria-hidden="true"></span>
+                </summary>
+                <ul>
+                  <li>Defensa en causas penales en todas las instancias</li>
+                  <li>Presentación de denuncias y querellas</li>
+                  <li>Asistencia a víctimas y medidas de protección</li>
+                  <li>Excarcelaciones y estrategias cautelares</li>
+                  <li>Programas de compliance y prevención del delito</li>
+                </ul>
+              </details>
+            </div>
+          </div>
+
+          <div class="services__group">
+            <h3 class="services__group-title">Servicios contables</h3>
+            <div class="service-accordion" role="list">
+              <details class="service-accordion__item">
+                <summary>
+                  <span class="service-accordion__title">📘 Contabilidad general</span>
+                  <span class="service-accordion__icon" aria-hidden="true"></span>
+                </summary>
+                <ul>
+                  <li>Armado de libros contables obligatorios (diario, inventario y balances)</li>
+                  <li>Registración de operaciones contables</li>
+                  <li>Elaboración de estados contables (balance general, estado de resultados)</li>
+                  <li>Certificaciones contables para trámites bancarios o judiciales</li>
+                  <li>Auditorías internas y externas</li>
+                </ul>
+              </details>
+
+              <details class="service-accordion__item">
+                <summary>
+                  <span class="service-accordion__title">🧾 Impositivos y fiscales</span>
+                  <span class="service-accordion__icon" aria-hidden="true"></span>
+                </summary>
+                <ul>
+                  <li>Inscripción y categorización en AFIP (monotributo, responsable inscripto)</li>
+                  <li>Liquidación de impuestos nacionales (IVA, Ganancias, Bienes Personales)</li>
+                  <li>Liquidación de impuestos provinciales (Ingresos Brutos, Sellos)</li>
+                  <li>Presentación de declaraciones juradas mensuales y anuales</li>
+                  <li>Atención de requerimientos y fiscalizaciones de AFIP y ARBA</li>
+                  <li>Asesoramiento en regímenes de retención y percepción</li>
+                </ul>
+              </details>
+
+              <details class="service-accordion__item">
+                <summary>
+                  <span class="service-accordion__title">🏢 Sociedades y emprendimientos</span>
+                  <span class="service-accordion__icon" aria-hidden="true"></span>
+                </summary>
+                <ul>
+                  <li>Constitución de sociedades (SRL, SA, SAS)</li>
+                  <li>Asesoramiento en estructura societaria y estatutos</li>
+                  <li>Presentación de balances ante IGJ o DPPJ</li>
+                  <li>Trámites ante organismos públicos (AFIP, IGJ, CNV)</li>
+                  <li>Planificación fiscal y contable para pymes y emprendedores</li>
+                </ul>
+              </details>
+
+              <details class="service-accordion__item">
+                <summary>
+                  <span class="service-accordion__title">🧑‍💼 Laborales y previsionales</span>
+                  <span class="service-accordion__icon" aria-hidden="true"></span>
+                </summary>
+                <ul>
+                  <li>Alta de empleadores en AFIP</li>
+                  <li>Liquidación de sueldos y cargas sociales</li>
+                  <li>Generación de recibos de sueldo</li>
+                  <li>Altas y bajas de empleados (SIPA, ART, obra social)</li>
+                  <li>Asesoramiento en convenios colectivos y legislación laboral</li>
+                  <li>Cálculo de indemnizaciones y liquidaciones finales</li>
+                </ul>
+              </details>
+            </div>
+          </div>
         </div>
       </section>
       <section class="chatbot" id="asistente">
@@ -190,14 +258,26 @@
         <div class="chatbot__widget">
           <div class="chatbot__messages" id="chatbot-messages" aria-live="polite"></div>
           <div class="chatbot__suggestions" aria-label="Consultas sugeridas">
-            <button type="button" data-question="Quisiera información sobre derecho inmobiliario">
+            <button type="button" data-question="Quisiera conocer los servicios legales disponibles">
+              Servicios legales
+            </button>
+            <button type="button" data-question="Necesito información sobre los servicios contables">
+              Servicios contables
+            </button>
+            <button type="button" data-question="Quiero asesoramiento en derecho inmobiliario">
               Derecho inmobiliario
             </button>
-            <button type="button" data-question="Necesito asesoramiento en derecho de familia">
-              Derecho de familia
+            <button type="button" data-question="Busco ayuda en contabilidad general">
+              Contabilidad general
             </button>
-            <button type="button" data-question="Me despidieron del trabajo, ¿me pueden ayudar?">
-              Derecho laboral
+            <button type="button" data-question="Necesito apoyo con impuestos y fiscalizaciones">
+              Impositivos y fiscales
+            </button>
+            <button type="button" data-question="Quiero saber más sobre sociedades y emprendimientos">
+              Sociedades y emprendimientos
+            </button>
+            <button type="button" data-question="Me interesa el servicio laboral y previsional contable">
+              Laborales y previsionales
             </button>
             <button type="button" data-question="¿Cuál es el teléfono de contacto?">Datos de contacto</button>
           </div>
@@ -288,6 +368,10 @@
                 <option value="comercial">Derecho comercial y societario</option>
                 <option value="civil">Derecho civil</option>
                 <option value="penal">Derecho penal</option>
+                <option value="contabilidad-general">Contabilidad general</option>
+                <option value="impositivos">Impositivos y fiscales</option>
+                <option value="sociedades-emprendimientos">Sociedades y emprendimientos</option>
+                <option value="laborales-previsionales">Laborales y previsionales</option>
                 <option value="otros">Otros</option>
               </select>
             </label>
@@ -356,6 +440,16 @@
             "Trabajamos de manera interdisciplinaria, combinando la mirada legal y contable para ofrecer respuestas ágiles y personalizadas a cada consulta.",
         },
         {
+          match: /(servicio legal|servicios legales|área legal|area legal|abogad)/,
+          response:
+            "Nuestros servicios legales incluyen derecho inmobiliario, de familia, laboral, comercial y societario, civil y penal. Contanos tu caso y te conectamos con el equipo jurídico indicado.",
+        },
+        {
+          match: /(servicio contable|servicios contables|contable|contabilidad|estudio contable)/,
+          response:
+            "Desde el área contable te acompañamos con contabilidad general, impuestos y fiscalizaciones, sociedades y emprendimientos, y gestiones laborales y previsionales. Contame qué necesitás y te guiamos paso a paso.",
+        },
+        {
           match: /inmobiliari|alquiler|alquilar|escritura|escrituraci|fideicomiso|propiedad|venta/,
           response:
             "En derecho inmobiliario te asistimos en boletos de compraventa, contratos de alquiler, escrituración y fideicomisos. Coordinamos todo el proceso para que tu operación sea segura.",
@@ -364,6 +458,12 @@
           match: /familia|divorci|alimento|cuidad|régimen|regimen|adopci|filiaci|violencia/,
           response:
             "El área de familia acompaña divorcios, convenios de alimentos y cuidado personal, sucesiones, adopciones y situaciones de violencia familiar con un enfoque humano y cercano.",
+        },
+        {
+          match:
+            /laboral y previsional|contabilidad laboral|liquidaci[óo]n de sueldos|cargas sociales|recibos de sueldo|alta de empleadores|empleadores en afip|altas y bajas de empleados|sipa|obra social|\bart\b|convenios colectivos|legislaci[óo]n laboral|liquidaciones finales contables/,
+          response:
+            "En materia laboral y previsional gestionamos el alta de empleadores en AFIP, la liquidación de sueldos y cargas sociales, la generación de recibos, las altas y bajas de personal en SIPA, ART u obra social, el asesoramiento en convenios colectivos y el cálculo de indemnizaciones y liquidaciones finales.",
         },
         {
           match: /laboral|trabaj|despido|liquidaci|indemnizaci|accidente/,
@@ -386,9 +486,27 @@
             "En derecho penal brindamos defensa en todas las instancias, presentación de denuncias y querellas, medidas de protección y planes de compliance preventivo.",
         },
         {
+          match:
+            /contabilidad general|libro[s]? contable[s]?|registraci[óo]n contable|estado[s]? contable[s]?|certificaci[óo]n contable[s]?|auditor[íi]a(s)?/,
+          response:
+            "En contabilidad general armamos los libros obligatorios, registramos operaciones, elaboramos estados contables, emitimos certificaciones para trámites bancarios o judiciales y realizamos auditorías internas y externas.",
+        },
+        {
+          match:
+            /impositiv|impuesto|afip|monotribut|ganancias|iva|bienes personales|arba|ingresos brutos|sellos|declaraci[óo]n jurada|retenci[óo]n|percepci[óo]n|fiscalizaci[óo]n|inscripci[óo]n|categorizaci[óo]n/,
+          response:
+            "El área impositiva se encarga de la inscripción y categorización en AFIP, la liquidación de impuestos nacionales y provinciales, la presentación de declaraciones juradas y la atención de requerimientos o fiscalizaciones, incluyendo regímenes de retención y percepción.",
+        },
+        {
+          match:
+            /sociedades y emprendimientos|balance ante igj|balances ante igj|dppj|cnv|planificaci[óo]n fiscal y contable|estructura societaria|tr[aá]mites ante organismos p[úu]blicos|pymes y emprendedores/,
+          response:
+            "Acompañamos a sociedades y emprendimientos con la constitución de figuras como SRL, SA o SAS, el armado de estructuras y estatutos, la presentación de balances ante IGJ o DPPJ, los trámites ante organismos como AFIP, IGJ o CNV y la planificación fiscal para pymes y emprendedores.",
+        },
+        {
           match: /(servicio|servicios|asesoramiento|ayuda|consulta|especialidad|área|area)/,
           response:
-            "Contamos con asesoramiento inmobiliario, de familia, laboral, comercial y societario, civil y penal. Contame brevemente tu situación y te indico el equipo ideal.",
+            "Contamos con asesoramiento legal (inmobiliario, familia, laboral, comercial y societario, civil y penal) y contable (contabilidad general, impuestos, sociedades y emprendimientos, laborales y previsionales). Contame brevemente tu situación y te indico el equipo ideal.",
         },
         {
           match: /(reuni[óo]n|reunion|agendar|reservar|turno|agenda|coordinar)/,
@@ -522,7 +640,7 @@
       if (chatbotMessages) {
         addMessage(
           "bot",
-          "Hola, soy el asistente virtual del Estudio Meraki. Contame qué tipo de consulta tenés y te orientaré."
+          "Hola, soy el asistente virtual del Estudio Meraki. Contame si necesitás asesoramiento legal o contable y te orientaré."
         );
       }
 

--- a/styles.css
+++ b/styles.css
@@ -274,6 +274,31 @@ main {
   color: var(--color-muted);
 }
 
+.services__groups {
+  display: grid;
+  gap: clamp(2rem, 4vw, 3rem);
+  margin-top: clamp(2.5rem, 5vw, 3.5rem);
+}
+
+@media (min-width: 900px) {
+  .services__groups {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+}
+
+.services__group {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.services__group-title {
+  font-size: clamp(1.35rem, 2vw, 1.6rem);
+  color: var(--color-primary-dark);
+  margin: 0;
+  font-weight: 600;
+}
+
 .service-accordion {
   display: grid;
   gap: 1rem;


### PR DESCRIPTION
## Summary
- restructure the services section into legal and accounting groups, adding the accounting offerings provided
- add chatbot quick replies and knowledge-base entries for the new accounting areas and refine the welcome message
- update the contact form options and styles to support the reorganized service layout

## Testing
- not run (static changes)

------
https://chatgpt.com/codex/tasks/task_e_68d440dd8548833297ec72092d5ed0d4