### PR TITLE
Add professional team section with placeholder portraits

### DIFF
--- a/assets/team-carolina-ibarra.svg
+++ b/assets/team-carolina-ibarra.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="640" viewBox="0 0 640 640">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d9488" />
+      <stop offset="1" stop-color="#14b8a6" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="640" rx="120" fill="url(#bg)" />
+  <circle cx="320" cy="250" r="132" fill="rgba(255,255,255,0.22)" />
+  <path
+    d="M320 340c-90 0-164 74-164 164v36h328v-36c0-90-74-164-164-164z"
+    fill="rgba(255,255,255,0.26)"
+  />
+  <text
+    x="50%"
+    y="52%"
+    font-family="'Work Sans', 'Segoe UI', sans-serif"
+    font-size="120"
+    fill="#ffffff"
+    text-anchor="middle"
+    font-weight="600"
+  >
+    CI
+  </text>
+</svg>

--- a/assets/team-diego-rojas.svg
+++ b/assets/team-diego-rojas.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="640" viewBox="0 0 640 640">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0" stop-color="#0f172a" />
+      <stop offset="1" stop-color="#2563eb" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="640" rx="120" fill="url(#bg)" />
+  <circle cx="320" cy="245" r="135" fill="rgba(255,255,255,0.24)" />
+  <path
+    d="M320 340c-96 0-176 80-176 176v24h352v-24c0-96-80-176-176-176z"
+    fill="rgba(255,255,255,0.3)"
+  />
+  <text
+    x="50%"
+    y="52%"
+    font-family="'Work Sans', 'Segoe UI', sans-serif"
+    font-size="120"
+    fill="#ffffff"
+    text-anchor="middle"
+    font-weight="600"
+  >
+    DR
+  </text>
+</svg>

--- a/assets/team-lucia-fernandez.svg
+++ b/assets/team-lucia-fernandez.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="640" viewBox="0 0 640 640">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#324694" />
+      <stop offset="1" stop-color="#6c8ad9" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="640" rx="120" fill="url(#bg)" />
+  <circle cx="320" cy="250" r="130" fill="rgba(255,255,255,0.28)" />
+  <path
+    d="M320 340c-88 0-160 72-160 160v40h320v-40c0-88-72-160-160-160z"
+    fill="rgba(255,255,255,0.32)"
+  />
+  <text
+    x="50%"
+    y="52%"
+    font-family="'Work Sans', 'Segoe UI', sans-serif"
+    font-size="120"
+    fill="#ffffff"
+    text-anchor="middle"
+    font-weight="600"
+  >
+    LF
+  </text>
+</svg>

--- a/assets/team-martina-suarez.svg
+++ b/assets/team-martina-suarez.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="640" viewBox="0 0 640 640">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#8b5cf6" />
+      <stop offset="1" stop-color="#ec4899" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="640" rx="120" fill="url(#bg)" />
+  <circle cx="320" cy="250" r="130" fill="rgba(255,255,255,0.25)" />
+  <path
+    d="M320 340c-92 0-170 74-170 170v30h340v-30c0-96-78-170-170-170z"
+    fill="rgba(255,255,255,0.28)"
+  />
+  <text
+    x="50%"
+    y="52%"
+    font-family="'Work Sans', 'Segoe UI', sans-serif"
+    font-size="120"
+    fill="#ffffff"
+    text-anchor="middle"
+    font-weight="600"
+  >
+    MS
+  </text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
         <img src="assets/logo-meraki.svg" alt="Logotipo Estudio Meraki" class="brand" />
         <nav class="site-nav" aria-label="Navegación principal">
           <a href="#sobre-el-estudio">El estudio</a>
+          <a href="#equipo">Equipo</a>
           <a href="#servicios">Servicios</a>
           <a href="#contacto">Contacto</a>
           <a class="site-nav__cta" href="https://wa.me/5491162576017" target="_blank" rel="noopener">
@@ -79,6 +80,83 @@
               Articulamos la mirada legal y contable para anticipar riesgos, optimizar recursos y diseñar
               estrategias sostenibles para tu vida o negocio.
             </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="team" id="equipo">
+        <div class="section-heading">
+          <span class="section-heading__eyebrow">Equipo profesional</span>
+          <h2>Abogadas y contadoras que combinan visión estratégica y humana</h2>
+          <p>
+            Conocé a quienes lideran cada especialidad. Su experiencia académica y de campo respalda las
+            soluciones integrales que ofrecemos día a día.
+          </p>
+        </div>
+        <div class="team__grid">
+          <article class="team-card">
+            <img
+              class="team-card__photo"
+              src="assets/team-lucia-fernandez.svg"
+              alt="Retrato profesional de Lucía Fernández"
+            />
+            <div class="team-card__content">
+              <h3>Lucía Fernández</h3>
+              <p class="team-card__role">Abogada especialista en derecho inmobiliario</p>
+              <ul>
+                <li>Magíster en Derecho Empresarial (UBA)</li>
+                <li>12 años liderando procesos de escrituración y fideicomisos</li>
+                <li>Docente invitada en cursos de contratos inmobiliarios</li>
+              </ul>
+            </div>
+          </article>
+          <article class="team-card">
+            <img
+              class="team-card__photo"
+              src="assets/team-martina-suarez.svg"
+              alt="Retrato profesional de Martina Suárez"
+            />
+            <div class="team-card__content">
+              <h3>Martina Suárez</h3>
+              <p class="team-card__role">Abogada de familia y resolución colaborativa</p>
+              <ul>
+                <li>Posgrado en Mediación Familiar (UCA)</li>
+                <li>10 años acompañando acuerdos de cuidado y sucesiones</li>
+                <li>Integrante del registro de mediadores del Ministerio de Justicia</li>
+              </ul>
+            </div>
+          </article>
+          <article class="team-card">
+            <img
+              class="team-card__photo"
+              src="assets/team-diego-rojas.svg"
+              alt="Retrato profesional de Diego Rojas"
+            />
+            <div class="team-card__content">
+              <h3>Diego Rojas</h3>
+              <p class="team-card__role">Contador público – planeamiento fiscal y societario</p>
+              <ul>
+                <li>Especialista en Tributación (UBA)</li>
+                <li>15 años asesorando pymes en reorganizaciones y compliance</li>
+                <li>Ex consultor senior en firmas Big Four</li>
+              </ul>
+            </div>
+          </article>
+          <article class="team-card">
+            <img
+              class="team-card__photo"
+              src="assets/team-carolina-ibarra.svg"
+              alt="Retrato profesional de Carolina Ibarra"
+            />
+            <div class="team-card__content">
+              <h3>Carolina Ibarra</h3>
+              <p class="team-card__role">Contadora pública especializada en gestión financiera</p>
+              <ul>
+                <li>MBA con orientación en finanzas (UTDT)</li>
+                <li>11 años diseñando tableros de control y proyecciones</li>
+                <li>Mentora de emprendedores en aceleradoras locales</li>
+              </ul>
+            </div>
           </article>
         </div>
       </section>

--- a/styles.css
+++ b/styles.css
@@ -199,6 +199,100 @@ main {
   text-align: center;
 }
 
+.team {
+  margin: 6rem auto 0;
+  max-width: var(--max-width);
+}
+
+.team__grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.team-card {
+  background: #fff;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-soft);
+  padding: 2.5rem 2rem 2rem;
+  display: grid;
+  gap: 1.5rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.team-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(50, 70, 148, 0.08), rgba(243, 195, 114, 0.1));
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+
+.team-card:hover::before,
+.team-card:focus-within::before {
+  opacity: 1;
+}
+
+.team-card__photo {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 4px solid rgba(50, 70, 148, 0.1);
+  box-shadow: 0 12px 25px rgba(37, 41, 82, 0.18);
+}
+
+.team-card__content {
+  display: grid;
+  gap: 0.75rem;
+  position: relative;
+  z-index: 1;
+}
+
+.team-card__content h3 {
+  font-family: var(--font-display);
+  font-size: 1.35rem;
+  margin: 0;
+}
+
+.team-card__role {
+  margin: 0;
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.team-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.5rem;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.team-card li {
+  line-height: 1.6;
+}
+
+@media (max-width: 720px) {
+  .team-card {
+    text-align: center;
+    padding: 2.25rem 1.75rem;
+  }
+
+  .team-card__photo {
+    margin: 0 auto;
+  }
+
+  .team-card ul {
+    justify-items: center;
+    padding-left: 0;
+    list-style-position: inside;
+  }
+}
+
 .section-heading__eyebrow {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add a new "Equipo" navigation link and team section describing the studio's abogadas y contadoras
- create responsive card layout and styles for professional profiles with hover accents
- include temporary SVG portrait placeholders for each integrante del equipo

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d44bf471488332b0f56f913b4a14e0