### PR TITLE
Agregar sección de recursos y preguntas frecuentes

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,8 @@
           <a href="#sobre-el-estudio">El estudio</a>
           <a href="#equipo">Equipo</a>
           <a href="#servicios">Servicios</a>
+          <a href="#recursos">Recursos</a>
+          <a href="#preguntas-frecuentes">Preguntas frecuentes</a>
           <a href="#contacto">Contacto</a>
           <a class="site-nav__cta" href="https://wa.me/5491162576017" target="_blank" rel="noopener">
             WhatsApp directo
@@ -324,6 +326,101 @@
           </div>
         </div>
       </section>
+
+      <section class="resources" id="recursos">
+        <div class="section-heading section-heading--center">
+          <span class="section-heading__eyebrow">Material para tu consulta</span>
+          <h2>Recursos descargables y guías prácticas</h2>
+          <p>
+            Prepará tu encuentro con el estudio con herramientas diseñadas por nuestro equipo. Te ayudan a
+            reunir documentación, ordenar tus dudas y proyectar los próximos pasos con claridad.
+          </p>
+        </div>
+        <div class="resources__grid">
+          <article class="resource-card">
+            <div class="resource-card__icon" aria-hidden="true">📘</div>
+            <h3>Guía para consultas legales</h3>
+            <p>
+              Checklist editable para reunir escrituras, contratos, DNI y toda la información relevante antes
+              de tu primera reunión legal.
+            </p>
+            <a class="button button--ghost" href="https://bit.ly/meraki-guia-legal" target="_blank" rel="noopener">
+              Descargar guía
+            </a>
+          </article>
+          <article class="resource-card">
+            <div class="resource-card__icon" aria-hidden="true">🧾</div>
+            <h3>Planilla impositiva anual</h3>
+            <p>
+              Modelo en formato spreadsheet para registrar ingresos, gastos deducibles y vencimientos
+              tributarios de manera ordenada.
+            </p>
+            <a class="button button--ghost" href="https://bit.ly/meraki-planilla-impositiva" target="_blank" rel="noopener">
+              Abrir planilla
+            </a>
+          </article>
+          <article class="resource-card">
+            <div class="resource-card__icon" aria-hidden="true">🏢</div>
+            <h3>Checklist sociedades</h3>
+            <p>
+              Listado con los pasos esenciales para constituir o regularizar sociedades SRL, SA o SAS en la
+              Ciudad de Buenos Aires.
+            </p>
+            <a class="button button--ghost" href="https://bit.ly/meraki-checklist-sociedades" target="_blank" rel="noopener">
+              Ver checklist
+            </a>
+          </article>
+        </div>
+      </section>
+
+      <section class="faq" id="preguntas-frecuentes">
+        <div class="section-heading section-heading--center">
+          <span class="section-heading__eyebrow">Resolvemos tus dudas</span>
+          <h2>Preguntas frecuentes sobre el estudio</h2>
+          <p>
+            Respondemos las inquietudes habituales sobre nuestra modalidad de trabajo, tiempos de respuesta y
+            documentación inicial. Si necesitás más información, escribinos directamente.
+          </p>
+        </div>
+        <div class="faq__list">
+          <details class="faq-item" open>
+            <summary>¿Cuál es el horario de atención?</summary>
+            <p>
+              Atendemos consultas de lunes a viernes de 9 a 18 h. Podés agendar videollamadas fuera de ese
+              horario con coordinación previa.
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>¿Ofrecen reuniones virtuales?</summary>
+            <p>
+              Sí, realizamos encuentros por Google Meet o Zoom. Compartinos tu disponibilidad y enviamos el
+              enlace para la videollamada.
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>¿Cómo prepararme para la primera entrevista?</summary>
+            <p>
+              Recomendamos completar las guías descargables, reunir documentación básica (DNI, constancias
+              fiscales, contratos) y listar tus objetivos y dudas principales.
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>¿Trabajan con personas y empresas de todo el país?</summary>
+            <p>
+              Sí. Gestionamos trámites en CABA y Provincia de Buenos Aires, y contamos con alianzas para
+              acompañar gestiones en otras jurisdicciones mediante firmas asociadas.
+            </p>
+          </details>
+          <details class="faq-item">
+            <summary>¿Qué medios de pago aceptan?</summary>
+            <p>
+              Aceptamos transferencias bancarias, Mercado Pago y, para planes mensuales, débitos automáticos.
+              Para trabajos puntuales cotizamos por proyecto con un presupuesto previo.
+            </p>
+          </details>
+        </div>
+      </section>
+
       <section class="chatbot" id="asistente">
         <div class="section-heading section-heading--center">
           <span class="section-heading__eyebrow">Asistente virtual</span>
@@ -356,6 +453,12 @@
             </button>
             <button type="button" data-question="Me interesa el servicio laboral y previsional contable">
               Laborales y previsionales
+            </button>
+            <button type="button" data-question="¿Tienen recursos o guías para prepararme?">
+              Recursos descargables
+            </button>
+            <button type="button" data-question="Quiero leer preguntas frecuentes sobre el estudio">
+              Preguntas frecuentes
             </button>
             <button type="button" data-question="¿Cuál es el teléfono de contacto?">Datos de contacto</button>
           </div>
@@ -475,6 +578,8 @@
         <a href="#inicio">Inicio</a>
         <a href="#sobre-el-estudio">El estudio</a>
         <a href="#servicios">Servicios</a>
+        <a href="#recursos">Recursos</a>
+        <a href="#preguntas-frecuentes">Preguntas frecuentes</a>
         <a href="#contacto">Contacto</a>
       </nav>
     </footer>
@@ -557,6 +662,31 @@
           match: /civil|contrato civil|daño|perjuicio|deuda|ejecuci|amparo|mediaci/,
           response:
             "El área civil cubre redacción de contratos, reclamos por daños, cobro de deudas, acciones de amparo y soluciones extrajudiciales.",
+        },
+        {
+          match: /(recurso|gu[ií]a|material|descargable|planilla|checklist|prepararme)/,
+          response:
+            "Podés descargar nuestra guía para consultas legales, la planilla impositiva anual y el checklist societario desde la sección Recursos del sitio. Cada documento te orienta sobre la información a reunir antes del encuentro.",
+        },
+        {
+          match: /(preguntas frecuentes|faq|duda frecuente|informaci[óo]n general)/,
+          response:
+            "En la sección Preguntas frecuentes encontrarás detalles sobre horarios de atención, reuniones virtuales, preparación para la primera entrevista, alcance geográfico y medios de pago del estudio.",
+        },
+        {
+          match: /(horario de atenci[óo]n|cu[aá]ndo atienden|horarios|disponibilidad)/,
+          response:
+            "Nuestro horario de atención es de lunes a viernes de 9 a 18 h. Podemos coordinar videollamadas en otros horarios si lo necesitás.",
+        },
+        {
+          match: /(reuni[oó]n virtual|videollamada|online|a distancia|remot)/,
+          response:
+            "Sí, trabajamos de forma presencial y virtual. Coordinamos reuniones por Google Meet o Zoom para facilitar el seguimiento de tu caso sin importar dónde estés.",
+        },
+        {
+          match: /(medio de pago|forma de pago|pagar|transferencia|mercado pago|tarjeta|cobranza)/,
+          response:
+            "Aceptamos transferencias bancarias, Mercado Pago y débitos automáticos para planes mensuales. Antes de comenzar te enviamos un presupuesto con el detalle de honorarios.",
         },
         {
           match: /penal|denuncia|querella|excarcelaci|delito|victima|víctima/,

--- a/styles.css
+++ b/styles.css
@@ -327,6 +327,8 @@ main {
 
 .about,
 .services,
+.resources,
+.faq,
 .chatbot,
 .contact {
   max-width: var(--max-width);
@@ -426,6 +428,87 @@ main {
 
 .service-accordion__item summary::-webkit-details-marker {
   display: none;
+}
+
+.resources__grid {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.25rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.resource-card {
+  display: grid;
+  gap: 1rem;
+  padding: clamp(1.75rem, 3vw, 2.25rem);
+  border-radius: var(--radius-md);
+  background: linear-gradient(160deg, rgba(243, 195, 114, 0.12), rgba(50, 70, 148, 0.08));
+  box-shadow: inset 0 0 0 1px rgba(243, 195, 114, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.resource-card:hover,
+.resource-card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 22px 35px rgba(50, 70, 148, 0.16);
+}
+
+.resource-card__icon {
+  font-size: 2.25rem;
+  line-height: 1;
+}
+
+.resource-card h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: var(--color-primary-dark);
+}
+
+.resource-card p {
+  margin: 0;
+  color: var(--color-muted);
+  line-height: 1.65;
+}
+
+.resource-card .button {
+  justify-self: start;
+}
+
+.faq__list {
+  display: grid;
+  gap: 1rem;
+}
+
+.faq-item {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(50, 70, 148, 0.18);
+  padding: 1.15rem 1.5rem;
+  background: rgba(50, 70, 148, 0.04);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.faq-item[open] {
+  background: #fff;
+  border-color: rgba(50, 70, 148, 0.35);
+  box-shadow: 0 16px 30px rgba(50, 70, 148, 0.08);
+}
+
+.faq-item summary {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: var(--color-primary-dark);
+  list-style: none;
+}
+
+.faq-item summary::marker,
+.faq-item summary::-webkit-details-marker {
+  display: none;
+}
+
+.faq-item p {
+  margin: 0.85rem 0 0;
+  line-height: 1.65;
+  color: var(--color-muted);
 }
 
 .service-accordion__title {


### PR DESCRIPTION
## Summary
- añadir una nueva sección de recursos descargables y una sección de preguntas frecuentes con información clave para las personas interesadas
- actualizar la navegación, los botones sugeridos y las respuestas del chatbot para reflejar el nuevo contenido
- incorporar estilos dedicados para las tarjetas de recursos y el acordeón de preguntas frecuentes

## Testing
- no se corrieron tests (sitio estático)


------
https://chatgpt.com/codex/tasks/task_e_68d47c14a1b08332afb1eb9635caf91f