### PR TITLE
Restore spacing below team profiles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -200,13 +200,14 @@ main {
 }
 
 .team {
-  margin: 6rem auto 0;
+  margin: 6rem auto clamp(3rem, 6vw, 5rem);
   max-width: var(--max-width);
+  padding-bottom: clamp(2.5rem, 5vw, 4rem);
 }
 
 .team__grid {
   display: grid;
-  gap: 2rem;
+  gap: clamp(1.75rem, 4vw, 2.75rem);
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
 }
 


### PR DESCRIPTION
## Summary
- add responsive bottom margin and padding to the team section to create comfortable spacing before the asesoramiento block

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d5e824b93083329b53a2e575e487d5