### PR TITLE
Remove Carolina Ibarra profile from team section

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,22 +142,6 @@
               </ul>
             </div>
           </article>
-          <article class="team-card">
-            <img
-              class="team-card__photo"
-              src="assets/team-carolina-ibarra.svg"
-              alt="Retrato profesional de Carolina Ibarra"
-            />
-            <div class="team-card__content">
-              <h3>Carolina Ibarra</h3>
-              <p class="team-card__role">Contador</p>
-              <ul>
-                <li>****************</li>
-                <li>****************</li>
-                <li>****************</li>
-              </ul>
-            </div>
-          </article>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- remove the Carolina Ibarra card from the team section, leaving only the remaining three profiles

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d5ef50a7348332b7271ee822101655