### PR TITLE
Remove secondary CTAs from team profiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,14 +148,6 @@
               >
                 Agendar consulta
               </a>
-              <a
-                class="team-card__link team-card__link--ghost"
-                href="https://www.linkedin.com/in/julietacardinalimerani"
-                target="_blank"
-                rel="noopener"
-              >
-                Perfil profesional
-              </a>
             </div>
           </article>
           <article class="team-card">
@@ -195,12 +187,6 @@
                 rel="noopener"
               >
                 Agendar consulta
-              </a>
-              <a
-                class="team-card__link team-card__link--ghost"
-                href="mailto:ejcmeraki@gmail.com?subject=Consulta%20para%20Viviana%20Merani"
-              >
-                Coordinar por email
               </a>
             </div>
           </article>
@@ -242,14 +228,6 @@
               >
                 Agendar consulta
               </a>
-              <a
-                class="team-card__link team-card__link--ghost"
-                href="https://www.linkedin.com/in/albertolassa"
-                target="_blank"
-                rel="noopener"
-              >
-                Perfil profesional
-              </a>
             </div>
           </article>
           <article class="team-card">
@@ -289,12 +267,6 @@
                 rel="noopener"
               >
                 Agendar consulta
-              </a>
-              <a
-                class="team-card__link team-card__link--ghost"
-                href="mailto:ejcmeraki@gmail.com?subject=Consulta%20para%20Agustin%20Lescano"
-              >
-                Coordinar por email
               </a>
             </div>
           </article>


### PR DESCRIPTION
## Summary
- remove the secondary "Perfil profesional" and "Coordinar por email" links from the team member cards to keep only the WhatsApp consultation CTA

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbf19cb3788332a1db8bdd59410917