### PR TITLE
Refine team section layout to avoid whitespace gaps

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -239,22 +239,21 @@ main {
 
 .team__grid {
   display: grid;
-  gap: clamp(1.75rem, 4vw, 2.75rem);
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  justify-content: center;
+  gap: clamp(1.5rem, 3vw, 2.25rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  align-items: stretch;
 }
 
 .team-card {
   background: #fff;
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-soft);
-  padding: 2.5rem 2.25rem 2.25rem;
-  display: grid;
+  padding: clamp(2rem, 4vw, 2.5rem);
+  display: flex;
+  flex-direction: column;
   gap: 1.75rem;
   position: relative;
   overflow: hidden;
-  width: min(100%, 400px);
-  justify-self: center;
 }
 
 .team-card::before {
@@ -309,7 +308,9 @@ main {
 .team-card__profile {
   display: flex;
   align-items: center;
-  gap: 1.5rem;
+  flex-direction: column;
+  gap: 1.25rem;
+  text-align: center;
   position: relative;
   z-index: 1;
 }
@@ -369,6 +370,7 @@ main {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+  justify-content: center;
   position: relative;
   z-index: 1;
 }
@@ -389,6 +391,8 @@ main {
   gap: 0.75rem;
   position: relative;
   z-index: 1;
+  justify-content: center;
+  margin-top: auto;
 }
 
 .team-card__link {


### PR DESCRIPTION
## Summary
- update the team grid to fit four profiles per row on wide screens and stretch cards evenly
- rework each team card with a centered avatar and flexible vertical layout to better fill the column
- center the tag list and call-to-action so the card content remains balanced

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dbf608a6ac8332a6f3b7627ab5df64