### PR TITLE
Set team grid to two columns

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -239,22 +239,27 @@ main {
 
 .team__grid {
   display: grid;
-  gap: clamp(1.75rem, 4vw, 2.75rem);
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  justify-content: center;
+  gap: clamp(1.5rem, 3vw, 2.25rem);
+  grid-template-columns: minmax(0, 1fr);
+  align-items: stretch;
+}
+
+@media (min-width: 720px) {
+  .team__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .team-card {
   background: #fff;
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-soft);
-  padding: 2.5rem 2.25rem 2.25rem;
-  display: grid;
+  padding: clamp(2rem, 4vw, 2.5rem);
+  display: flex;
+  flex-direction: column;
   gap: 1.75rem;
   position: relative;
   overflow: hidden;
-  width: min(100%, 400px);
-  justify-self: center;
 }
 
 .team-card::before {
@@ -309,7 +314,9 @@ main {
 .team-card__profile {
   display: flex;
   align-items: center;
-  gap: 1.5rem;
+  flex-direction: column;
+  gap: 1.25rem;
+  text-align: center;
   position: relative;
   z-index: 1;
 }
@@ -369,6 +376,7 @@ main {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+  justify-content: center;
   position: relative;
   z-index: 1;
 }
@@ -389,6 +397,8 @@ main {
   gap: 0.75rem;
   position: relative;
   z-index: 1;
+  justify-content: center;
+  margin-top: auto;
 }
 
 .team-card__link {


### PR DESCRIPTION
## Summary
- adjust the team grid to use a single column on small screens and two columns on wider viewports so only two profiles render per row

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbf608a6ac8332a6f3b7627ab5df64