### PR TITLE
Add bilingual support with language toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,835 @@
+const yearElement = document.getElementById("year");
+if (yearElement) {
+  yearElement.textContent = new Date().getFullYear();
+}
+
+const chatbotMessages = document.getElementById("chatbot-messages");
+const chatbotForm = document.getElementById("chatbot-form");
+const chatbotInput = document.getElementById("chatbot-input");
+const chatbotSuggestionButtons = document.querySelectorAll(
+  ".chatbot__suggestions button[data-question]"
+);
+const languageToggle = document.getElementById("language-toggle");
+const contactForm = document.getElementById("contact-form");
+const contactFormStatus = document.getElementById("contact-form-status");
+
+const translations = {
+  es: {
+    "meta.title": "Estudio Meraki · Asesoramiento legal y contable",
+    "nav.study": "El estudio",
+    "nav.team": "Equipo",
+    "nav.services": "Servicios",
+    "nav.methodology": "Metodología",
+    "nav.testimonials": "Testimonios",
+    "nav.contact": "Contacto",
+    "nav.label": "Navegación principal",
+    "nav.whatsapp": "WhatsApp directo",
+    "language.toggle": "EN",
+    "language.toggleLabel": "Cambiar a inglés",
+    "hero.kicker": "Soluciones legales y contables a medida",
+    "hero.title": "Estudio Meraki",
+    "hero.lead": "Acompañamos a personas, familias y empresas con una mirada integral. Nos enfocamos en la escucha activa, el análisis preciso y la creación de estrategias que generen confianza a largo plazo.",
+    "hero.primaryCta": "Conocé nuestros servicios",
+    "hero.secondaryCta": "Reservá una reunión",
+    "hero.metric1Value": "+12 años",
+    "hero.metric1Label": "De experiencia interdisciplinaria",
+    "hero.metric2Value": "96%",
+    "hero.metric2Label": "De consultas resueltas en menos de 48 h",
+    "hero.metric3Value": "5.0",
+    "hero.metric3Label": "Promedio de satisfacción de clientes",
+    "about.eyebrow": "Sobre el estudio",
+    "about.title": "Un equipo interdisciplinario comprometido con tus proyectos",
+    "about.lead": "Somos abogados y contadores que unen experiencia jurídica y contable para acompañarte con un servicio personalizado. Diseñamos soluciones que contemplan la dimensión humana, financiera y legal de cada caso.",
+    "about.card1Title": "👥 Acompañamiento cercano",
+    "about.card1Body": "Generamos vínculos de confianza a través de reuniones periódicas, seguimiento activo y comunicación clara en cada instancia del proceso.",
+    "about.card2Title": "📚 Actualización permanente",
+    "about.card2Body": "Participamos en capacitaciones y redes profesionales para ofrecerte respuestas ágiles basadas en la normativa vigente y las mejores prácticas del mercado.",
+    "about.card3Title": "🤝 Visión integral",
+    "about.card3Body": "Articulamos la mirada legal y contable para anticipar riesgos, optimizar recursos y diseñar estrategias sostenibles para tu vida o negocio.",
+    "team.eyebrow": "Equipo profesional",
+    "team.title": "Abogados y contadores que combinan visión estratégica y humana",
+    "team.lead": "Conocé a quienes lideran cada especialidad. Su experiencia académica y de campo respalda las soluciones integrales que ofrecemos día a día.",
+    "team.julieta.alt": "Fotografía de Julieta Elizabeth Cardinali Merani",
+    "team.julieta.name": "Julieta Elizabeth Cardinali Merani",
+    "team.julieta.role": "Abogada",
+    "team.julieta.location": "Ciudad Autónoma y Provincia de Buenos Aires",
+    "team.julieta.bio": "Lidera el abordaje integral de asuntos de familia e inmobiliarios, priorizando la escucha activa y las soluciones colaborativas.",
+    "team.julieta.highlight1": "<span aria-hidden=\"true\">🎓</span> Abogacía (UADE) con orientación en derecho privado",
+    "team.julieta.highlight2": "<span aria-hidden=\"true\">⚖️</span> Especialista en derecho de familia y sucesiones",
+    "team.julieta.highlight3": "<span aria-hidden=\"true\">📜</span> Diplomada en derecho inmobiliario registral",
+    "team.julieta.tagsLabel": "Áreas principales de Julieta",
+    "team.julieta.tag1": "Derecho de familia",
+    "team.julieta.tag2": "Sucesiones",
+    "team.julieta.tag3": "Derecho inmobiliario",
+    "team.viviana.initials": "Iniciales de Viviana Elizabeth Merani",
+    "team.viviana.name": "Viviana Elizabeth Merani",
+    "team.viviana.role": "Abogada",
+    "team.viviana.location": "Ciudad Autónoma y Provincia de Buenos Aires",
+    "team.viviana.bio": "Conduce estrategias integrales en derecho civil, comercial y laboral, priorizando la prevención de conflictos mediante acuerdos sostenibles y acompañamiento personalizado.",
+    "team.viviana.highlight1": "<span aria-hidden=\"true\">🎓</span> Abogada (UBA) con posgrado en derecho civil y comercial",
+    "team.viviana.highlight2": "<span aria-hidden=\"true\">⚖️</span> Mediadora prejudicial matriculada con enfoque en resolución colaborativa",
+    "team.viviana.highlight3": "<span aria-hidden=\"true\">🤝</span> Amplia experiencia en asesoramiento a pymes y familias empresarias",
+    "team.viviana.tagsLabel": "Áreas principales de Viviana",
+    "team.viviana.tag1": "Derecho civil",
+    "team.viviana.tag2": "Derecho comercial",
+    "team.viviana.tag3": "Mediación",
+    "team.alberto.alt": "Fotografía de Alberto Lassa",
+    "team.alberto.name": "Alberto Lassa",
+    "team.alberto.role": "Contador Público",
+    "team.alberto.location": "Ciudad Autónoma y Provincia de Buenos Aires",
+    "team.alberto.bio": "Coordina los servicios contables e impositivos del estudio, acompañando a empresas y emprendedores con planificación fiscal, cumplimiento normativo y reportes financieros claros.",
+    "team.alberto.highlight1": "<span aria-hidden=\"true\">📊</span> Más de 30 años asesorando en impuestos nacionales y provinciales",
+    "team.alberto.highlight2": "<span aria-hidden=\"true\">🏢</span> Experto en armado de estructuras societarias y balances ante IGJ",
+    "team.alberto.highlight3": "<span aria-hidden=\"true\">🤝</span> Especialista en liquidación de haberes y convenios colectivos",
+    "team.alberto.tagsLabel": "Áreas principales de Alberto",
+    "team.alberto.tag1": "Planificación fiscal",
+    "team.alberto.tag2": "Sociedades",
+    "team.alberto.tag3": "Liquidación de sueldos",
+    "team.agustin.alt": "Fotografía de Agustin Lescano",
+    "team.agustin.name": "Agustin Lescano",
+    "team.agustin.role": "Abogado",
+    "team.agustin.location": "Ciudad Autónoma y Provincia de Buenos Aires",
+    "team.agustin.bio": "Lidera el asesoramiento laboral del estudio, acompañando a trabajadores y pymes en negociaciones, auditorías y estrategias de prevención de conflictos.",
+    "team.agustin.highlight1": "<span aria-hidden=\"true\">🎓</span> Abogado (UBA) con especialización en derecho penal y laboral",
+    "team.agustin.highlight2": "<span aria-hidden=\"true\">📑</span> Docente Universitario",
+    "team.agustin.highlight3": "<span aria-hidden=\"true\">⚖️</span> Maestría en Derecho Laboral",
+    "team.agustin.tagsLabel": "Áreas principales de Agustin",
+    "team.agustin.tag1": "Derecho laboral",
+    "team.agustin.tag2": "Negociaciones colectivas",
+    "team.agustin.tag3": "Prevención de conflictos",
+    "team.consultCta": "Agendar consulta",
+    "services.eyebrow": "Áreas de práctica",
+    "services.title": "Seleccioná el asesoramiento que necesitás",
+    "services.lead": "Desplegá cada especialidad para conocer las gestiones en las que podemos acompañarte. Si tenés un caso particular, escribinos y armamos una propuesta a medida.",
+    "services.legal.title": "Servicios legales",
+    "services.legal.inmobiliario.summary": "🏡 Derecho inmobiliario",
+    "services.legal.inmobiliario.items": "<li>Boleto de compraventa y seguimiento de escrituración</li><li>Contratos de locación para vivienda, comerciales y temporarios</li><li>Due diligence y asesoría integral en operaciones inmobiliarias</li><li>Regularización dominial y trámites registrales</li><li>Constitución y administración legal de fideicomisos</li>",
+    "services.legal.familia.summary": "👨‍👩‍👧 Derecho de familia",
+    "services.legal.familia.items": "<li>Divorcios de común acuerdo o contenciosos</li><li>Convenios de alimentos, cuidado personal y régimen de comunicación</li><li>Sucesiones y planificación hereditaria</li><li>Adopciones, filiaciones y uniones convivenciales</li><li>Acompañamiento integral ante situaciones de violencia familiar</li>",
+    "services.legal.laboral.summary": "💼 Derecho laboral",
+    "services.legal.laboral.items": "<li>Asesoramiento a empleadores y trabajadores</li><li>Reclamos por despidos, accidentes laborales e indemnizaciones</li><li>Liquidaciones finales y cálculo de haberes</li><li>Negociaciones individuales y colectivas</li><li>Representación ante el Ministerio de Trabajo y auditorías</li>",
+    "services.legal.comercial.summary": "📄 Derecho comercial y societario",
+    "services.legal.comercial.items": "<li>Constitución de sociedades (SRL, SA, SAS) y acuerdos societarios</li><li>Redacción de estatutos, actas y contratos comerciales</li><li>Due diligence y reorganizaciones empresariales</li><li>Asesoramiento en contratos civiles y comerciales</li><li>Gestión de cumplimiento normativo y gobierno corporativo</li>",
+    "services.legal.civil.summary": "⚖️ Derecho civil",
+    "services.legal.civil.items": "<li>Redacción y revisión de contratos civiles</li><li>Reclamos por daños y perjuicios</li><li>Cobro de deudas y ejecuciones</li><li>Acciones de amparo y medidas cautelares</li><li>Resolución de conflictos extrajudiciales</li>",
+    "services.legal.penal.summary": "🛡️ Derecho penal",
+    "services.legal.penal.items": "<li>Defensa en causas penales en todas las instancias</li><li>Presentación de denuncias y querellas</li><li>Asistencia a víctimas y medidas de protección</li><li>Excarcelaciones y estrategias cautelares</li><li>Programas de compliance y prevención del delito</li>",
+    "services.accounting.title": "Servicios contables",
+    "services.accounting.general.summary": "📘 Contabilidad general",
+    "services.accounting.general.items": "<li>Armado de libros contables obligatorios (diario, inventario y balances)</li><li>Registración de operaciones contables</li><li>Elaboración de estados contables (balance general, estado de resultados)</li><li>Certificaciones contables para trámites bancarios o judiciales</li><li>Auditorías internas y externas</li>",
+    "services.accounting.tax.summary": "🧾 Impositivos y fiscales",
+    "services.accounting.tax.items": "<li>Inscripción y categorización en AFIP (monotributo, responsable inscripto)</li><li>Liquidación de impuestos nacionales (IVA, Ganancias, Bienes Personales)</li><li>Liquidación de impuestos provinciales (Ingresos Brutos, Sellos)</li><li>Presentación de declaraciones juradas mensuales y anuales</li><li>Atención de requerimientos y fiscalizaciones de AFIP y ARBA</li><li>Asesoramiento en regímenes de retención y percepción</li>",
+    "services.accounting.business.summary": "🏢 Sociedades y emprendimientos",
+    "services.accounting.business.items": "<li>Constitución de sociedades (SRL, SA, SAS)</li><li>Asesoramiento en estructura societaria y estatutos</li><li>Presentación de balances ante IGJ o DPPJ</li><li>Trámites ante organismos públicos (AFIP, IGJ, CNV)</li><li>Planificación fiscal y contable para pymes y emprendedores</li>",
+    "services.accounting.labor.summary": "🧑‍💼 Laborales y previsionales",
+    "services.accounting.labor.items": "<li>Alta de empleadores en AFIP</li><li>Liquidación de sueldos y cargas sociales</li><li>Generación de recibos de sueldo</li><li>Altas y bajas de empleados (SIPA, ART, obra social)</li><li>Asesoramiento en convenios colectivos y legislación laboral</li><li>Cálculo de indemnizaciones y liquidaciones finales</li>",
+    "process.eyebrow": "Metodología Meraki",
+    "process.title": "Trabajamos con un proceso claro y acompañado",
+    "process.lead": "Desde el primer contacto hasta el cierre del caso mantenemos una comunicación transparente para que sepas en qué instancia estamos y cuáles son los siguientes pasos.",
+    "process.step1Title": "Diagnóstico inicial",
+    "process.step1Body": "Escuchamos tu consulta en detalle y recopilamos la documentación necesaria para entender el contexto legal y/o contable.",
+    "process.step2Title": "Estrategia a medida",
+    "process.step2Body": "Diseñamos un plan integral que contempla riesgos, oportunidades y tiempos estimados, y lo validamos con vos antes de avanzar.",
+    "process.step3Title": "Ejecución y seguimiento",
+    "process.step3Body": "Gestionamos cada instancia operativa con reportes periódicos, reuniones de actualización y acceso a la documentación digital.",
+    "process.step4Title": "Cierre y acompañamiento",
+    "process.step4Body": "Presentamos los resultados, definimos próximos pasos y quedamos disponibles para el soporte continuo que necesites.",
+    "testimonials.eyebrow": "Experiencias reales",
+    "testimonials.title": "Las personas que nos eligen hablan de nuestro compromiso",
+    "testimonials.lead": "Historias de pymes, familias y emprendedores que confiaron en el Estudio Meraki para resolver procesos sensibles y estratégicos.",
+    "testimonials.quote1": "“Nos acompañaron en la reorganización societaria y logramos ordenar la documentación sin detener la operación del negocio. La disponibilidad del equipo fue clave.”",
+    "testimonials.name1": "Lucía Fernández",
+    "testimonials.role1": "Directora de Pyme tecnológica",
+    "testimonials.quote2": "“Encontré una escucha humana en un momento complejo de mi familia. El plan de acción fue claro y me sentí acompañada en cada etapa del proceso.”",
+    "testimonials.name2": "Martina Thompson",
+    "testimonials.role2": "Cliente de derecho de familia",
+    "testimonials.quote3": "“El seguimiento mensual contable e impositivo nos permitió anticipar vencimientos y mejorar el flujo de caja. Hoy tomamos decisiones con información clara.”",
+    "testimonials.name3": "Gonzalo Schuster",
+    "testimonials.role3": "Cliente pyme industria textil",
+    "cta.eyebrow": "Agenda inteligente",
+    "cta.title": "Reservá una consulta virtual",
+    "cta.lead": "Coordinamos una videollamada de 20 minutos para evaluar tu caso y sugerirte el plan de trabajo ideal. Recibí un resumen con los próximos pasos y honorarios estimados.",
+    "cta.primaryCta": "Agenda por WhatsApp",
+    "cta.secondaryCta": "Quiero dejar mi consulta",
+    "chatbot.eyebrow": "Asistente virtual",
+    "chatbot.title": "Chateá con Meraki para resolver tus dudas rápidas",
+    "chatbot.lead": "Consultá sobre nuestras áreas de asesoramiento o pedí los datos de contacto. Nuestro asistente te orienta y, si el caso lo requiere, te comparte los medios para hablar directamente con el equipo.",
+    "chatbot.suggestionsLabel": "Consultas sugeridas",
+    "chatbot.suggestion1": "Servicios legales",
+    "chatbot.suggestion1Question": "Quisiera conocer los servicios legales disponibles",
+    "chatbot.suggestion2": "Servicios contables",
+    "chatbot.suggestion2Question": "Necesito información sobre los servicios contables",
+    "chatbot.suggestion3": "Derecho inmobiliario",
+    "chatbot.suggestion3Question": "Quiero asesoramiento en derecho inmobiliario",
+    "chatbot.suggestion4": "Contabilidad general",
+    "chatbot.suggestion4Question": "Busco ayuda en contabilidad general",
+    "chatbot.suggestion5": "Impositivos y fiscales",
+    "chatbot.suggestion5Question": "Necesito apoyo con impuestos y fiscalizaciones",
+    "chatbot.suggestion6": "Sociedades y emprendimientos",
+    "chatbot.suggestion6Question": "Quiero saber más sobre sociedades y emprendimientos",
+    "chatbot.suggestion7": "Laborales y previsionales",
+    "chatbot.suggestion7Question": "Me interesa el servicio laboral y previsional contable",
+    "chatbot.suggestion8": "Datos de contacto",
+    "chatbot.suggestion8Question": "¿Cuál es el teléfono de contacto?",
+    "chatbot.inputLabel": "Escribí tu consulta",
+    "chatbot.placeholder": "Escribí tu consulta acá...",
+    "chatbot.submit": "Enviar",
+    "chatbot.initialMessage": "Hola, soy el asistente virtual del Estudio Meraki. Contame si necesitás asesoramiento legal o contable y te orientaré.",
+    "chatbot.contactDetails": "Podés comunicarte al +54 9 11 6257-6017 (WhatsApp o llamada) o escribirnos a ejcmeraki@gmail.com. También podés visitarnos en Guardia Vieja 3732 4 E, Almagro, CABA.",
+    "chatbot.fallbackIntro": "No estoy seguro de haber entendido tu consulta.",
+    "chatbot.responses.greeting": "¡Hola! Soy el asistente virtual del Estudio Meraki. ¿En qué puedo ayudarte hoy?",
+    "chatbot.responses.thanks": "¡Gracias a vos por escribirnos! Si necesitás algo más, contanos y seguimos en contacto.",
+    "chatbot.responses.about": "Somos un equipo interdisciplinario de abogadas y contadoras. Acompañamos a personas, familias y empresas con soluciones legales y contables integrales.",
+    "chatbot.responses.team": "Trabajamos de manera interdisciplinaria, combinando la mirada legal y contable para ofrecer respuestas ágiles y personalizadas a cada consulta.",
+    "chatbot.responses.legalServices": "Nuestros servicios legales incluyen derecho inmobiliario, de familia, laboral, comercial y societario, civil y penal. Contanos tu caso y te conectamos con el equipo jurídico indicado.",
+    "chatbot.responses.accountingServices": "Desde el área contable te acompañamos con contabilidad general, impuestos y fiscalizaciones, sociedades y emprendimientos, y gestiones laborales y previsionales. Contame qué necesitás y te guiamos paso a paso.",
+    "chatbot.responses.inmobiliario": "En derecho inmobiliario te asistimos en boletos de compraventa, contratos de alquiler, escrituración y fideicomisos. Coordinamos todo el proceso para que tu operación sea segura.",
+    "chatbot.responses.familia": "El área de familia acompaña divorcios, convenios de alimentos y cuidado personal, sucesiones, adopciones y situaciones de violencia familiar con un enfoque humano y cercano.",
+    "chatbot.responses.laboralAccounting": "En materia laboral y previsional gestionamos el alta de empleadores en AFIP, la liquidación de sueldos y cargas sociales, la generación de recibos, las altas y bajas de personal en SIPA, ART u obra social, el asesoramiento en convenios colectivos y el cálculo de indemnizaciones y liquidaciones finales.",
+    "chatbot.responses.laboral": "Nuestro equipo laboral asesora a personas y empresas en despidos, liquidaciones, indemnizaciones, accidentes de trabajo y negociaciones ante el Ministerio de Trabajo.",
+    "chatbot.responses.comercial": "En derecho comercial y societario constituimos sociedades (SRL, SA, SAS), redactamos estatutos y contratos, y acompañamos reorganizaciones y cumplimiento normativo.",
+    "chatbot.responses.civil": "El área civil cubre redacción de contratos, reclamos por daños, cobro de deudas, acciones de amparo y soluciones extrajudiciales.",
+    "chatbot.responses.penal": "En derecho penal brindamos defensa en todas las instancias, presentación de denuncias y querellas, medidas de protección y planes de compliance preventivo.",
+    "chatbot.responses.contabilidad": "En contabilidad general armamos los libros obligatorios, registramos operaciones, elaboramos estados contables, emitimos certificaciones para trámites bancarios o judiciales y realizamos auditorías internas y externas.",
+    "chatbot.responses.impositivos": "El área impositiva se encarga de la inscripción y categorización en AFIP, la liquidación de impuestos nacionales y provinciales, la presentación de declaraciones juradas y la atención de requerimientos o fiscalizaciones, incluyendo regímenes de retención y percepción.",
+    "chatbot.responses.sociedades": "Acompañamos a sociedades y emprendimientos con la constitución de figuras como SRL, SA o SAS, el armado de estructuras y estatutos, la presentación de balances ante IGJ o DPPJ, los trámites ante organismos como AFIP, IGJ o CNV y la planificación fiscal para pymes y emprendedores.",
+    "chatbot.responses.general": "Contamos con asesoramiento legal (inmobiliario, familia, laboral, comercial y societario, civil y penal) y contable (contabilidad general, impuestos, sociedades y emprendimientos, laborales y previsionales). Contame brevemente tu situación y te indico el equipo ideal.",
+    "chatbot.responses.reunion": "Coordinamos reuniones presenciales en Almagro o virtuales según tu disponibilidad. Escribinos por WhatsApp o completá el formulario de contacto y te respondemos en menos de 24 horas hábiles.",
+    "chatbot.responses.horarios": "Atendemos de lunes a viernes de 9 a 18 h. Podemos coordinar una reunión presencial o virtual según tu disponibilidad.",
+    "chatbot.responses.direccion": "Estamos en Guardia Vieja 3732 4 E, en el barrio de Almagro, Ciudad Autónoma de Buenos Aires. Te esperamos con cita previa.",
+    "chatbot.responses.aprecio": "¡Me alegra que la información te sirva! Si aparece otra duda, escribime cuando quieras.",
+    "chatbot.responses.despedida": "¡Hasta luego! Cuando quieras retomar la conversación, escribinos y seguimos charlando.",
+    "contact.eyebrow": "Agendemos una reunión",
+    "contact.title": "Contanos en qué podemos ayudarte",
+    "contact.lead": "Elegí el medio que prefieras o completá el formulario. Respondemos dentro de las 24 horas hábiles con los próximos pasos para tu consulta.",
+    "contact.cardTitle": "Datos de contacto",
+    "contact.phoneLabel": "Teléfono",
+    "contact.emailLabel": "Email",
+    "contact.addressLabel": "Dirección",
+    "contact.address": "<p><span aria-hidden=\"true\">📍</span> Guardia Vieja 3732 4 E<br />Almagro, Ciudad Autónoma de Buenos Aires</p><p><span aria-hidden=\"true\">📍</span> Alicia Moreau de Justo 740 3ero 1<br />Puerto Madero, Ciudad Autónoma de Buenos Aires</p>",
+    "contact.hoursLabel": "Horarios",
+    "contact.hours": "Lunes a Viernes de 9 a 18 h",
+    "contact.whatsappCta": "Escribir por WhatsApp",
+    "contact.emailCta": "Enviar correo",
+    "contact.formTitle": "Enviá tu consulta",
+    "contact.formName": "Nombre completo",
+    "contact.formNamePlaceholder": "María Pérez",
+    "contact.formEmail": "Email",
+    "contact.formEmailPlaceholder": "nombre@correo.com",
+    "contact.formPhone": "Teléfono",
+    "contact.formPhonePlaceholder": "11 2345 6789",
+    "contact.formReason": "Motivo de la consulta",
+    "contact.formReasonOptions": "<option value=\"\" disabled selected>Elegí una opción</option><option value=\"inmobiliario\">Derecho inmobiliario</option><option value=\"familia\">Derecho de familia</option><option value=\"laboral\">Derecho laboral</option><option value=\"comercial\">Derecho comercial y societario</option><option value=\"civil\">Derecho civil</option><option value=\"penal\">Derecho penal</option><option value=\"contabilidad-general\">Contabilidad general</option><option value=\"impositivos\">Impositivos y fiscales</option><option value=\"sociedades-emprendimientos\">Sociedades y emprendimientos</option><option value=\"laborales-previsionales\">Laborales y previsionales</option><option value=\"otros\">Otros</option>",
+    "contact.formDetails": "Contanos más detalles",
+    "contact.formDetailsPlaceholder": "Describí tu consulta",
+    "contact.formSubject": "Nueva consulta desde el sitio web",
+    "contact.formSubmit": "Enviar consulta",
+    "contact.formDisclaimer": "Al enviar tus datos aceptás ser contactado/a por un representante del Estudio Meraki.",
+    "contact.formSendingButton": "Enviando...",
+    "contact.formSendingStatus": "Enviando tu consulta...",
+    "contact.formSuccess": "¡Gracias! Recibimos tu consulta y te contactaremos dentro de las próximas 24 horas hábiles.",
+    "contact.formErrorFallback": "No pudimos enviar el formulario en este momento. Escribinos a ejcmeraki@gmail.com o por WhatsApp.",
+    "contact.formNetworkError": "Ocurrió un inconveniente al enviar tu consulta. Por favor escribinos a ejcmeraki@gmail.com o por WhatsApp.",
+    "footer.copy": "© <span id=\"year\"></span> Estudio Meraki. Todos los derechos reservados.",
+    "footer.navLabel": "Navegación en el pie",
+    "footer.home": "Inicio",
+    "footer.study": "El estudio",
+    "footer.services": "Servicios",
+    "footer.methodology": "Metodología",
+    "footer.testimonials": "Testimonios",
+    "footer.contact": "Contacto",
+  },
+  en: {
+    "meta.title": "Meraki Firm · Legal and Accounting Advisory",
+    "nav.study": "The firm",
+    "nav.team": "Team",
+    "nav.services": "Services",
+    "nav.methodology": "Methodology",
+    "nav.testimonials": "Testimonials",
+    "nav.contact": "Contact",
+    "nav.label": "Primary navigation",
+    "nav.whatsapp": "Direct WhatsApp",
+    "language.toggle": "ES",
+    "language.toggleLabel": "Switch to Spanish",
+    "hero.kicker": "Tailored legal and accounting solutions",
+    "hero.title": "Meraki Firm",
+    "hero.lead": "We support individuals, families, and companies with an integral approach. We focus on active listening, precise analysis, and crafting strategies that build long-term trust.",
+    "hero.primaryCta": "Explore our services",
+    "hero.secondaryCta": "Book a meeting",
+    "hero.metric1Value": "+12 years",
+    "hero.metric1Label": "Of interdisciplinary experience",
+    "hero.metric2Value": "96%",
+    "hero.metric2Label": "Of inquiries resolved within 48 hours",
+    "hero.metric3Value": "5.0",
+    "hero.metric3Label": "Client satisfaction average",
+    "about.eyebrow": "About the firm",
+    "about.title": "An interdisciplinary team committed to your projects",
+    "about.lead": "We are attorneys and accountants who combine legal and accounting expertise to deliver a personalized service. We design solutions that consider every human, financial, and legal angle of each case.",
+    "about.card1Title": "👥 Close guidance",
+    "about.card1Body": "We build trusting relationships through regular meetings, proactive follow-up, and clear communication at every stage of the process.",
+    "about.card2Title": "📚 Continuous learning",
+    "about.card2Body": "We join training programs and professional networks to offer agile responses based on current regulations and best market practices.",
+    "about.card3Title": "🤝 Integral vision",
+    "about.card3Body": "We connect the legal and accounting perspectives to anticipate risks, optimise resources, and design sustainable strategies for your life or business.",
+    "team.eyebrow": "Professional team",
+    "team.title": "Attorneys and accountants with strategic and human vision",
+    "team.lead": "Meet the leaders of each specialty. Their academic and field experience sustains the comprehensive solutions we deliver every day.",
+    "team.julieta.alt": "Portrait of Julieta Elizabeth Cardinali Merani",
+    "team.julieta.name": "Julieta Elizabeth Cardinali Merani",
+    "team.julieta.role": "Attorney",
+    "team.julieta.location": "City and Province of Buenos Aires",
+    "team.julieta.bio": "Leads the integral handling of family and real estate matters, prioritising active listening and collaborative solutions.",
+    "team.julieta.highlight1": "<span aria-hidden=\"true\">🎓</span> Law degree (UADE) with a focus on private law",
+    "team.julieta.highlight2": "<span aria-hidden=\"true\">⚖️</span> Specialist in family law and probate",
+    "team.julieta.highlight3": "<span aria-hidden=\"true\">📜</span> Diploma in real estate registry law",
+    "team.julieta.tagsLabel": "Julieta’s main areas",
+    "team.julieta.tag1": "Family law",
+    "team.julieta.tag2": "Probate",
+    "team.julieta.tag3": "Real estate law",
+    "team.viviana.initials": "Initials of Viviana Elizabeth Merani",
+    "team.viviana.name": "Viviana Elizabeth Merani",
+    "team.viviana.role": "Attorney",
+    "team.viviana.location": "City and Province of Buenos Aires",
+    "team.viviana.bio": "Leads comprehensive strategies in civil, commercial, and labour law, prioritising prevention through sustainable agreements and personalised support.",
+    "team.viviana.highlight1": "<span aria-hidden=\"true\">🎓</span> Attorney (UBA) with postgraduate studies in civil and commercial law",
+    "team.viviana.highlight2": "<span aria-hidden=\"true\">⚖️</span> Registered pre-trial mediator with a collaborative resolution focus",
+    "team.viviana.highlight3": "<span aria-hidden=\"true\">🤝</span> Extensive experience advising SMEs and family businesses",
+    "team.viviana.tagsLabel": "Viviana’s main areas",
+    "team.viviana.tag1": "Civil law",
+    "team.viviana.tag2": "Commercial law",
+    "team.viviana.tag3": "Mediation",
+    "team.alberto.alt": "Portrait of Alberto Lassa",
+    "team.alberto.name": "Alberto Lassa",
+    "team.alberto.role": "Certified Public Accountant",
+    "team.alberto.location": "City and Province of Buenos Aires",
+    "team.alberto.bio": "Heads the firm’s accounting and tax services, helping companies and entrepreneurs with tax planning, compliance, and clear financial reporting.",
+    "team.alberto.highlight1": "<span aria-hidden=\"true\">📊</span> 30+ years advising on national and provincial taxes",
+    "team.alberto.highlight2": "<span aria-hidden=\"true\">🏢</span> Expert in corporate structures and financial statements before IGJ",
+    "team.alberto.highlight3": "<span aria-hidden=\"true\">🤝</span> Specialist in payroll and collective bargaining agreements",
+    "team.alberto.tagsLabel": "Alberto’s main areas",
+    "team.alberto.tag1": "Tax planning",
+    "team.alberto.tag2": "Corporate structures",
+    "team.alberto.tag3": "Payroll management",
+    "team.agustin.alt": "Portrait of Agustin Lescano",
+    "team.agustin.name": "Agustin Lescano",
+    "team.agustin.role": "Attorney",
+    "team.agustin.location": "City and Province of Buenos Aires",
+    "team.agustin.bio": "Leads the firm’s labour advisory services, guiding workers and SMEs through negotiations, audits, and conflict-prevention strategies.",
+    "team.agustin.highlight1": "<span aria-hidden=\"true\">🎓</span> Attorney (UBA) specialised in criminal and labour law",
+    "team.agustin.highlight2": "<span aria-hidden=\"true\">📑</span> University lecturer",
+    "team.agustin.highlight3": "<span aria-hidden=\"true\">⚖️</span> Master’s degree in Labour Law",
+    "team.agustin.tagsLabel": "Agustin’s main areas",
+    "team.agustin.tag1": "Labour law",
+    "team.agustin.tag2": "Collective bargaining",
+    "team.agustin.tag3": "Conflict prevention",
+    "team.consultCta": "Schedule a consultation",
+    "services.eyebrow": "Practice areas",
+    "services.title": "Choose the advisory service you need",
+    "services.lead": "Expand each specialty to explore how we can support you. If your case is unique, write to us and we will design a tailored proposal.",
+    "services.legal.title": "Legal services",
+    "services.legal.inmobiliario.summary": "🏡 Real estate law",
+    "services.legal.inmobiliario.items": "<li>Purchase agreements and deed follow-up</li><li>Residential, commercial, and short-term lease contracts</li><li>Due diligence and end-to-end support for real estate transactions</li><li>Title regularisation and registry filings</li><li>Creation and legal management of trusts</li>",
+    "services.legal.familia.summary": "👨‍👩‍👧 Family law",
+    "services.legal.familia.items": "<li>Uncontested and contested divorces</li><li>Child support, custody, and parenting agreements</li><li>Probate processes and estate planning</li><li>Adoptions, parentage, and domestic partnerships</li><li>Comprehensive support in family violence situations</li>",
+    "services.legal.laboral.summary": "💼 Labour law",
+    "services.legal.laboral.items": "<li>Advice for employers and employees</li><li>Claims for dismissals, workplace accidents, and compensation</li><li>Severance settlements and wage calculations</li><li>Individual and collective negotiations</li><li>Representation before the Labour Ministry and audits</li>",
+    "services.legal.comercial.summary": "📄 Commercial and corporate law",
+    "services.legal.comercial.items": "<li>Incorporation of companies (LLC, Corp., SAS) and shareholders’ agreements</li><li>Drafting of bylaws, minutes, and commercial contracts</li><li>Due diligence and corporate reorganisations</li><li>Advisory on civil and commercial agreements</li><li>Compliance management and corporate governance</li>",
+    "services.legal.civil.summary": "⚖️ Civil law",
+    "services.legal.civil.items": "<li>Drafting and review of civil contracts</li><li>Claims for damages and losses</li><li>Debt collection and enforcement</li><li>Amparo actions and precautionary measures</li><li>Out-of-court dispute resolution</li>",
+    "services.legal.penal.summary": "🛡️ Criminal law",
+    "services.legal.penal.items": "<li>Defence in criminal cases at every stage</li><li>Filing complaints and private prosecutions</li><li>Support for victims and protective measures</li><li>Bail requests and precautionary strategies</li><li>Compliance programmes and crime prevention</li>",
+    "services.accounting.title": "Accounting services",
+    "services.accounting.general.summary": "📘 General accounting",
+    "services.accounting.general.items": "<li>Preparation of mandatory accounting books (journal, inventory, and balance)</li><li>Bookkeeping of daily transactions</li><li>Preparation of financial statements (balance sheet, income statement)</li><li>Accounting certifications for banking or court procedures</li><li>Internal and external audits</li>",
+    "services.accounting.tax.summary": "🧾 Tax and fiscal",
+    "services.accounting.tax.items": "<li>AFIP registration and tax status (monotributo, registered taxpayer)</li><li>National tax filings (VAT, Income Tax, Personal Assets)</li><li>Provincial tax filings (Gross Income, Stamp Tax)</li><li>Monthly and annual tax returns</li><li>Handling AFIP and ARBA requirements and audits</li><li>Advice on withholding and collection regimes</li>",
+    "services.accounting.business.summary": "🏢 Companies and ventures",
+    "services.accounting.business.items": "<li>Company incorporation (LLC, Corp., SAS)</li><li>Advice on corporate structures and bylaws</li><li>Financial statement filings with IGJ or DPPJ</li><li>Procedures with public agencies (AFIP, IGJ, CNV)</li><li>Tax and accounting planning for SMEs and entrepreneurs</li>",
+    "services.accounting.labor.summary": "🧑‍💼 Labour and social security",
+    "services.accounting.labor.items": "<li>Employer registration with AFIP</li><li>Payroll and social security calculations</li><li>Issuing pay slips</li><li>Employee onboarding and offboarding (SIPA, workers’ compensation, healthcare)</li><li>Advice on collective bargaining agreements and labour regulations</li><li>Calculation of severance and final settlements</li>",
+    "process.eyebrow": "Meraki methodology",
+    "process.title": "We work with a clear and supportive process",
+    "process.lead": "From the first contact to closing the case we keep transparent communication so you always know where we stand and the next steps.",
+    "process.step1Title": "Initial diagnosis",
+    "process.step1Body": "We listen to your inquiry in detail and gather the documents needed to understand the legal and/or accounting context.",
+    "process.step2Title": "Tailored strategy",
+    "process.step2Body": "We design an integral plan that considers risks, opportunities, and timelines, and validate it with you before moving forward.",
+    "process.step3Title": "Execution and follow-up",
+    "process.step3Body": "We handle each operational stage with regular updates, review meetings, and access to digital documentation.",
+    "process.step4Title": "Closure and support",
+    "process.step4Body": "We present the outcomes, define the next steps, and remain available for the ongoing support you need.",
+    "testimonials.eyebrow": "Real experiences",
+    "testimonials.title": "The people who choose us speak about our commitment",
+    "testimonials.lead": "Stories from SMEs, families, and entrepreneurs who trusted Meraki to manage sensitive and strategic processes.",
+    "testimonials.quote1": "“They guided us through a corporate reorganisation and we were able to organise the paperwork without stopping business operations. The team’s availability was key.”",
+    "testimonials.name1": "Lucía Fernández",
+    "testimonials.role1": "Tech SME director",
+    "testimonials.quote2": "“I found a human approach during a complex family moment. The action plan was clear and I felt supported every step of the way.”",
+    "testimonials.name2": "Martina Thompson",
+    "testimonials.role2": "Family law client",
+    "testimonials.quote3": "“Monthly accounting and tax follow-up helped us anticipate deadlines and improve cash flow. Today we make decisions with clear information.”",
+    "testimonials.name3": "Gonzalo Schuster",
+    "testimonials.role3": "Textile industry SME client",
+    "cta.eyebrow": "Smart scheduling",
+    "cta.title": "Book an online consultation",
+    "cta.lead": "We set up a 20-minute video call to assess your case and suggest the best plan. Receive a summary with next steps and estimated fees.",
+    "cta.primaryCta": "Schedule on WhatsApp",
+    "cta.secondaryCta": "Leave us your inquiry",
+    "chatbot.eyebrow": "Virtual assistant",
+    "chatbot.title": "Chat with Meraki to solve quick questions",
+    "chatbot.lead": "Ask about our advisory areas or request contact details. The assistant will guide you and, if needed, connect you directly with the team.",
+    "chatbot.suggestionsLabel": "Suggested questions",
+    "chatbot.suggestion1": "Legal services",
+    "chatbot.suggestion1Question": "I’d like to know the legal services available",
+    "chatbot.suggestion2": "Accounting services",
+    "chatbot.suggestion2Question": "I need information about accounting services",
+    "chatbot.suggestion3": "Real estate law",
+    "chatbot.suggestion3Question": "I’m looking for advice on real estate law",
+    "chatbot.suggestion4": "General accounting",
+    "chatbot.suggestion4Question": "I need help with general accounting",
+    "chatbot.suggestion5": "Tax and fiscal",
+    "chatbot.suggestion5Question": "I need support with taxes and audits",
+    "chatbot.suggestion6": "Companies and ventures",
+    "chatbot.suggestion6Question": "I want details about companies and ventures",
+    "chatbot.suggestion7": "Labour and social security",
+    "chatbot.suggestion7Question": "I’m interested in labour and social security services",
+    "chatbot.suggestion8": "Contact details",
+    "chatbot.suggestion8Question": "What’s the contact phone number?",
+    "chatbot.inputLabel": "Type your question",
+    "chatbot.placeholder": "Write your question here...",
+    "chatbot.submit": "Send",
+    "chatbot.initialMessage": "Hi! I’m Meraki’s virtual assistant. Tell me if you need legal or accounting support and I’ll guide you.",
+    "chatbot.contactDetails": "You can reach us at +54 9 11 6257-6017 (WhatsApp or call) or email ejcmeraki@gmail.com. We also welcome visits at Guardia Vieja 3732 4 E, Almagro, Buenos Aires.",
+    "chatbot.fallbackIntro": "I’m not sure I understood your question.",
+    "chatbot.responses.greeting": "Hi! I’m Meraki’s virtual assistant. How can I help you today?",
+    "chatbot.responses.thanks": "Thanks for reaching out! If you need anything else just let us know and we’ll stay in touch.",
+    "chatbot.responses.about": "We’re an interdisciplinary team of attorneys and accountants. We support people, families, and companies with comprehensive legal and accounting solutions.",
+    "chatbot.responses.team": "We work interdisciplinarily, combining legal and accounting perspectives to offer agile, personalised answers to every inquiry.",
+    "chatbot.responses.legalServices": "Our legal services cover real estate, family, labour, commercial and corporate, civil, and criminal law. Tell us about your case and we’ll connect you with the right legal specialist.",
+    "chatbot.responses.accountingServices": "Our accounting team supports you with general accounting, taxes and audits, companies and ventures, plus labour and social security procedures. Share what you need and we’ll guide you step by step.",
+    "chatbot.responses.inmobiliario": "In real estate law we assist with purchase agreements, lease contracts, deeds, and trusts. We coordinate the whole process so your transaction is safe.",
+    "chatbot.responses.familia": "Our family law area assists with divorces, parenting agreements, probate, adoptions, and family violence cases with a human, empathetic focus.",
+    "chatbot.responses.laboralAccounting": "For labour and social security matters we handle employer registration, payroll and social charges, pay slips, onboarding and offboarding in SIPA, workers’ compensation and healthcare, collective agreements, and severance calculations.",
+    "chatbot.responses.laboral": "Our labour law team advises people and companies on dismissals, settlements, compensation, workplace accidents, and negotiations before the Labour Ministry.",
+    "chatbot.responses.comercial": "In commercial and corporate law we set up companies (LLC, Corp., SAS), draft bylaws and contracts, and support reorganisations and compliance.",
+    "chatbot.responses.civil": "The civil law area covers contract drafting, damage claims, debt collection, amparo actions, and out-of-court solutions.",
+    "chatbot.responses.penal": "In criminal law we provide defence at every stage, file complaints and private prosecutions, support victims, and design compliance programmes to prevent crime.",
+    "chatbot.responses.contabilidad": "In general accounting we prepare mandatory books, record transactions, produce financial statements, issue certifications, and carry out internal and external audits.",
+    "chatbot.responses.impositivos": "Our tax area manages AFIP registration, national and provincial tax filings, monthly and annual returns, plus requirements or audits including withholding and collection regimes.",
+    "chatbot.responses.sociedades": "We support companies and ventures with incorporating LLCs, corporations, or SAS, structuring bylaws, filing financial statements with IGJ or DPPJ, handling procedures with AFIP, IGJ, or CNV, and planning taxes for SMEs and entrepreneurs.",
+    "chatbot.responses.general": "We offer legal advice (real estate, family, labour, commercial and corporate, civil, and criminal) and accounting advice (general accounting, taxes, companies and ventures, labour and social security). Tell me briefly about your situation and I’ll guide you to the right team.",
+    "chatbot.responses.reunion": "We schedule in-person meetings in Almagro or online sessions depending on your availability. Write to us on WhatsApp or fill in the contact form and we’ll reply within 24 business hours.",
+    "chatbot.responses.horarios": "We’re available Monday to Friday from 9 a.m. to 6 p.m. We can arrange an in-person or online meeting according to your schedule.",
+    "chatbot.responses.direccion": "We’re located at Guardia Vieja 3732 4 E, in Almagro, Buenos Aires City. Visits are by appointment.",
+    "chatbot.responses.aprecio": "I’m glad the information was useful! If any other question comes up, just message me again.",
+    "chatbot.responses.despedida": "See you soon! Whenever you want to continue the conversation, write to us and we’ll pick it up from there.",
+    "contact.eyebrow": "Let’s schedule a meeting",
+    "contact.title": "Tell us how we can help",
+    "contact.lead": "Choose your preferred channel or fill in the form. We reply within 24 business hours with the next steps for your inquiry.",
+    "contact.cardTitle": "Contact details",
+    "contact.phoneLabel": "Phone",
+    "contact.emailLabel": "Email",
+    "contact.addressLabel": "Address",
+    "contact.address": "<p><span aria-hidden=\"true\">📍</span> Guardia Vieja 3732 4 E<br />Almagro, Buenos Aires City</p><p><span aria-hidden=\"true\">📍</span> Alicia Moreau de Justo 740 3rd 1<br />Puerto Madero, Buenos Aires City</p>",
+    "contact.hoursLabel": "Office hours",
+    "contact.hours": "Monday to Friday from 9 a.m. to 6 p.m.",
+    "contact.whatsappCta": "Write on WhatsApp",
+    "contact.emailCta": "Send email",
+    "contact.formTitle": "Send your inquiry",
+    "contact.formName": "Full name",
+    "contact.formNamePlaceholder": "Jane Doe",
+    "contact.formEmail": "Email",
+    "contact.formEmailPlaceholder": "name@email.com",
+    "contact.formPhone": "Phone",
+    "contact.formPhonePlaceholder": "+1 555 123 4567",
+    "contact.formReason": "Reason for inquiry",
+    "contact.formReasonOptions": "<option value=\"\" disabled selected>Select an option</option><option value=\"inmobiliario\">Real estate law</option><option value=\"familia\">Family law</option><option value=\"laboral\">Labour law</option><option value=\"comercial\">Commercial & corporate law</option><option value=\"civil\">Civil law</option><option value=\"penal\">Criminal law</option><option value=\"contabilidad-general\">General accounting</option><option value=\"impositivos\">Tax & fiscal</option><option value=\"sociedades-emprendimientos\">Companies & ventures</option><option value=\"laborales-previsionales\">Labour & social security</option><option value=\"otros\">Other</option>",
+    "contact.formDetails": "Share more details",
+    "contact.formDetailsPlaceholder": "Describe your inquiry",
+    "contact.formSubject": "New inquiry from the website",
+    "contact.formSubmit": "Submit inquiry",
+    "contact.formDisclaimer": "By submitting your details you agree to be contacted by a Meraki representative.",
+    "contact.formSendingButton": "Sending...",
+    "contact.formSendingStatus": "Sending your inquiry...",
+    "contact.formSuccess": "Thank you! We received your inquiry and will contact you within the next 24 business hours.",
+    "contact.formErrorFallback": "We couldn’t send the form right now. Please email ejcmeraki@gmail.com or reach us on WhatsApp.",
+    "contact.formNetworkError": "Something went wrong while sending your inquiry. Please email ejcmeraki@gmail.com or contact us on WhatsApp.",
+    "footer.copy": "© <span id=\"year\"></span> Meraki Firm. All rights reserved.",
+    "footer.navLabel": "Footer navigation",
+    "footer.home": "Home",
+    "footer.study": "The firm",
+    "footer.services": "Services",
+    "footer.methodology": "Methodology",
+    "footer.testimonials": "Testimonials",
+    "footer.contact": "Contact",
+  },
+};
+const knowledgeBaseDefinitions = [
+  {
+    responseKey: "chatbot.responses.greeting",
+    patterns: { es: "(hola|buen[oa]s (d[ií]as|tardes|noches)|hey|qué tal|que tal|saludo)", en: "(hi|hello|hey|good (morning|afternoon|evening))" },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.thanks",
+    patterns: { es: "(gracias|muchas gracias|te agradezco|muy amable)", en: "(thanks|thank you|appreciate it)" },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.about",
+    patterns: {
+      es: "(qu[ié]n sos|quien sos|qu[ié]nes son|quienes son|qu[eé] es meraki|que es meraki|sobre ustedes|qu[eé] hacen)",
+      en: "(who (are|is) (you|meraki)|about you|what do you do)",
+    },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.team",
+    patterns: { es: "(experiencia|equipo|profesionales|trayectoria|interdisciplinario)", en: "(experience|team|professionals|interdisciplinary)" },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.legalServices",
+    patterns: { es: "(servicio legal|servicios legales|área legal|area legal|abogad)", en: "(legal service|legal services|attorney|lawyer|law area)" },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.accountingServices",
+    patterns: { es: "(servicio contable|servicios contables|contable|contabilidad|estudio contable)", en: "(accounting service|accounting|bookkeeping|accountant|tax service)" },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.inmobiliario",
+    patterns: { es: "inmobiliari|alquiler|alquilar|escritura|escrituraci|fideicomiso|propiedad|venta", en: "(real estate|property|rental|lease|deed|trust|sell|purchase)" },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.familia",
+    patterns: { es: "familia|divorci|alimento|cuidad|régimen|regimen|adopci|filiaci|violencia", en: "(family law|divorce|alimony|custody|parenting|adoption|violence)" },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.laboralAccounting",
+    patterns: {
+      es: "laboral y previsional|contabilidad laboral|liquidaci[óo]n de sueldos|cargas sociales|recibos de sueldo|alta de empleadores|empleadores en afip|altas y bajas de empleados|sipa|obra social|\\bart\\b|convenios colectivos|legislaci[óo]n laboral|liquidaciones finales contables",
+      en: "(payroll|social security|employer registration|wage slip|sipa|workers'? comp|healthcare|collective agreement|labour settlement)",
+    },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.laboral",
+    patterns: { es: "laboral|trabaj|despido|liquidaci|indemnizaci|accidente", en: "(labour|labor|employment|dismissal|layoff|settlement|compensation|accident)" },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.comercial",
+    patterns: { es: "societari|comercial|empresa|sociedad|estatuto|s\\.?a|srl|sas|contrato comercial", en: "(commercial|corporate|company|bylaw|s\\.?a|llc|sas|shareholder|business contract)" },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.civil",
+    patterns: { es: "civil|contrato civil|daño|perjuicio|deuda|ejecuci|amparo|mediaci", en: "(civil|contract|damages|debt|enforcement|injunction|mediation)" },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.penal",
+    patterns: { es: "penal|denuncia|querella|excarcelaci|delito|victima|víctima", en: "(criminal|crime|complaint|lawsuit|bail|victim|defen[cs]e)" },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.contabilidad",
+    patterns: { es: "contabilidad general|libro[s]? contable[s]?|registraci[óo]n contable|estado[s]? contable[s]?|certificaci[óo]n contable[s]?|auditor[íi]a(s)?", en: "(accounting book|bookkeeping|financial statement|accounting certification|audit)" },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.impositivos",
+    patterns: { es: "impositiv|impuesto|afip|monotribut|ganancias|iva|bienes personales|arba|ingresos brutos|sellos|declaraci[óo]n jurada|retenci[óo]n|percepci[óo]n|fiscalizaci[óo]n|inscripci[óo]n|categorizaci[óo]n", en: "(tax|afip|vat|income tax|personal assets|gross income|withholding|audit|registration|classification)" },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.sociedades",
+    patterns: { es: "sociedades y emprendimientos|balance ante igj|balances ante igj|dppj|cnv|planificaci[óo]n fiscal y contable|estructura societaria|tr[aá]mites ante organismos p[úu]blicos|pymes y emprendedores", en: "(company|venture|startup|igj|cnv|corporate structure|business planning|public agency|sme|entrepreneur)" },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.general",
+    patterns: { es: "(servicio|servicios|asesoramiento|ayuda|consulta|especialidad|área|area)", en: "(service|services|advice|support|consultation|specialty|area)" },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.reunion",
+    patterns: { es: "(reuni[óo]n|reunion|agendar|reservar|turno|agenda|coordinar)", en: "(meeting|schedule|book|appointment|call|coordination)" },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.horarios",
+    patterns: { es: "horario|hora|atenci|disponibilidad|agenda|turno", en: "(hours|schedule|availability|open|opening)" },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.direccion",
+    patterns: { es: "direcci|ubicaci|dónde están|donde estan", en: "(address|location|where are you)" },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.contactDetails",
+    patterns: { es: "correo|mail|email|escribir|contacto|tel[eé]fono|whatsapp|llamar|comunicar", en: "(phone|call|email|mail|contact|whats?app|reach)" },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.aprecio",
+    patterns: { es: "(gracias por la ayuda|muy claro|perfecto|genial)", en: "(thanks for the help|very clear|perfect|great|awesome)" },
+    flags: { es: "", en: "i" },
+  },
+  {
+    responseKey: "chatbot.responses.despedida",
+    patterns: { es: "(adios|chau|hasta luego|nos vemos)", en: "(goodbye|bye|see you|later)" },
+    flags: { es: "", en: "i" },
+  },
+];
+
+const directContactKeywordsMap = {
+  es: /(tel[eé]fono|whatsapp|contacto directo|correo|email|llamar|celular|celu)/,
+  en: /(phone|whats?app|direct contact|email|mail|call|cell)/i,
+};
+
+const timeLocales = {
+  es: "es-AR",
+  en: "en-US",
+};
+let currentLanguage = localStorage.getItem("preferredLanguage") || "es";
+let knowledgeBase = [];
+let fallbackAnswer = "";
+let directContactKeywords = directContactKeywordsMap[currentLanguage] || directContactKeywordsMap.es;
+
+function getTranslation(key, language = currentLanguage) {
+  const dictionary = translations[language];
+  if (dictionary && Object.prototype.hasOwnProperty.call(dictionary, key)) {
+    return dictionary[key];
+  }
+  const fallbackDictionary = translations.es;
+  return fallbackDictionary[key] || "";
+}
+
+function buildKnowledgeBase(language) {
+  return knowledgeBaseDefinitions
+    .map((definition) => {
+      const patternSource = definition.patterns[language] || definition.patterns.es;
+      if (!patternSource) return null;
+      const flags = definition.flags[language] || definition.flags.es || "";
+      const pattern = new RegExp(patternSource, flags);
+      const responseKey = definition.responseKey;
+      const responseText =
+        responseKey === "chatbot.contactDetails"
+          ? getTranslation("chatbot.contactDetails", language)
+          : getTranslation(responseKey, language);
+      return { match: pattern, responseKey, response: responseText };
+    })
+    .filter(Boolean);
+}
+
+function formatTime(date) {
+  const locale = timeLocales[currentLanguage] || timeLocales.es;
+  return date.toLocaleTimeString(locale, {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function addMessage(role, text) {
+  if (!chatbotMessages) return;
+  const bubble = document.createElement("div");
+  bubble.classList.add("chatbot__bubble", `chatbot__bubble--${role}`);
+
+  const messageText = document.createElement("p");
+  messageText.textContent = text;
+  bubble.appendChild(messageText);
+
+  const timestamp = document.createElement("time");
+  const now = new Date();
+  timestamp.dateTime = now.toISOString();
+  timestamp.textContent = formatTime(now);
+  bubble.appendChild(timestamp);
+
+  chatbotMessages.appendChild(bubble);
+  chatbotMessages.scrollTop = chatbotMessages.scrollHeight;
+}
+
+function setContactStatus(messageOrKey, type, { isKey = false } = {}) {
+  if (!contactFormStatus) return;
+  const message = isKey ? getTranslation(messageOrKey) : messageOrKey;
+  contactFormStatus.textContent = message;
+  contactFormStatus.classList.remove("form__status--success", "form__status--error");
+  if (type) {
+    contactFormStatus.classList.add(`form__status--${type}`);
+  }
+  if (isKey) {
+    contactFormStatus.dataset.statusKey = messageOrKey;
+  } else {
+    delete contactFormStatus.dataset.statusKey;
+  }
+}
+
+function applyTranslations(language) {
+  currentLanguage = language;
+  localStorage.setItem("preferredLanguage", currentLanguage);
+  document.documentElement.lang = currentLanguage;
+  document.body.dataset.language = currentLanguage;
+
+  const title = getTranslation("meta.title");
+  if (title) {
+    document.title = title;
+  }
+
+  document.querySelectorAll("[data-i18n]").forEach((element) => {
+    const key = element.getAttribute("data-i18n");
+    if (!key) return;
+    const translation = getTranslation(key);
+    if (translation !== undefined) {
+      element.innerHTML = translation;
+    }
+  });
+
+  document.querySelectorAll("[data-i18n-attr]").forEach((element) => {
+    const attrList = element.getAttribute("data-i18n-attr");
+    if (!attrList) return;
+    attrList.split(",").forEach((item) => {
+      const [attr, key] = item.split(":").map((value) => value.trim());
+      if (!attr || !key) return;
+      const translation = getTranslation(key);
+      if (translation !== undefined) {
+        element.setAttribute(attr, translation);
+      }
+    });
+  });
+
+  if (contactFormStatus && contactFormStatus.dataset.statusKey) {
+    const statusTranslation = getTranslation(contactFormStatus.dataset.statusKey);
+    if (statusTranslation) {
+      contactFormStatus.textContent = statusTranslation;
+    }
+  }
+
+  rebuildTranslationDependentData(currentLanguage);
+}
+
+function rebuildTranslationDependentData(language) {
+  knowledgeBase = buildKnowledgeBase(language);
+  directContactKeywords = directContactKeywordsMap[language] || directContactKeywordsMap.es;
+  fallbackAnswer = `${getTranslation("chatbot.fallbackIntro", language)} ${getTranslation("chatbot.contactDetails", language)}`.trim();
+
+  if (chatbotMessages) {
+    chatbotMessages.innerHTML = "";
+    addMessage("bot", getTranslation("chatbot.initialMessage", language));
+  }
+
+  if (contactForm) {
+    const submitButton = contactForm.querySelector('button[type="submit"]');
+    if (submitButton && !contactFormStatus?.dataset.statusKey) {
+      submitButton.textContent = getTranslation("contact.formSubmit", language);
+    }
+  }
+}
+
+function findResponse(message) {
+  const normalized = message.toLowerCase();
+  if (directContactKeywords.test(normalized)) {
+    return getTranslation("chatbot.contactDetails");
+  }
+
+  for (const item of knowledgeBase) {
+    if (item.match.test(normalized)) {
+      return item.response;
+    }
+  }
+
+  return fallbackAnswer;
+}
+
+function handleUserMessage(message) {
+  const trimmed = message.trim();
+  if (!trimmed) return;
+  addMessage("user", trimmed);
+
+  window.setTimeout(() => {
+    const reply = findResponse(trimmed);
+    addMessage("bot", reply);
+  }, 350);
+}
+
+if (chatbotForm && chatbotInput) {
+  chatbotForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const userMessage = chatbotInput.value;
+    chatbotInput.value = "";
+    handleUserMessage(userMessage);
+  });
+}
+
+chatbotSuggestionButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    const { question } = button.dataset;
+    if (!question) return;
+    if (chatbotInput) {
+      chatbotInput.value = "";
+      chatbotInput.focus();
+    }
+    handleUserMessage(question);
+  });
+});
+
+if (languageToggle) {
+  languageToggle.addEventListener("click", () => {
+    const nextLanguage = currentLanguage === "es" ? "en" : "es";
+    applyTranslations(nextLanguage);
+  });
+}
+
+const contactFormSubmitHandler = async (event) => {
+  if (!contactForm) return;
+  event.preventDefault();
+
+  const submitButton = contactForm.querySelector('button[type="submit"]');
+  if (submitButton) {
+    submitButton.disabled = true;
+    submitButton.textContent = getTranslation("contact.formSendingButton");
+  }
+
+  setContactStatus("contact.formSendingStatus", "", { isKey: true });
+
+  try {
+    const formData = new FormData(contactForm);
+    const response = await fetch("https://formsubmit.co/ajax/ejcmeraki@gmail.com", {
+      method: "POST",
+      headers: { Accept: "application/json" },
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => null);
+      if (data && (data.message || data.error)) {
+        setContactStatus(data.message || data.error, "error");
+      } else {
+        setContactStatus("contact.formErrorFallback", "error", { isKey: true });
+      }
+      return;
+    }
+
+    setContactStatus("contact.formSuccess", "success", { isKey: true });
+    contactForm.reset();
+  } catch (error) {
+    setContactStatus("contact.formNetworkError", "error", { isKey: true });
+  } finally {
+    if (submitButton) {
+      submitButton.disabled = false;
+      submitButton.textContent = getTranslation("contact.formSubmit");
+    }
+  }
+};
+
+if (contactForm && window.fetch) {
+  contactForm.addEventListener("submit", contactFormSubmitHandler);
+}
+
+applyTranslations(currentLanguage);

--- a/index.html
+++ b/index.html
@@ -23,42 +23,62 @@
       </div>
       <div class="site-header__inner">
         <img src="assets/logo-meraki.svg" alt="Logotipo Estudio Meraki" class="brand" />
-        <nav class="site-nav" aria-label="Navegación principal">
-          <a href="#sobre-el-estudio">El estudio</a>
-          <a href="#equipo">Equipo</a>
-          <a href="#servicios">Servicios</a>
-          <a href="#metodologia">Metodología</a>
-          <a href="#testimonios">Testimonios</a>
-          <a href="#contacto">Contacto</a>
-          <a class="site-nav__cta" href="https://wa.me/5491162576017" target="_blank" rel="noopener">
+        <nav
+          class="site-nav"
+          aria-label="Navegación principal"
+          data-i18n-attr="aria-label:nav.label"
+        >
+          <a href="#sobre-el-estudio" data-i18n="nav.study">El estudio</a>
+          <a href="#equipo" data-i18n="nav.team">Equipo</a>
+          <a href="#servicios" data-i18n="nav.services">Servicios</a>
+          <a href="#metodologia" data-i18n="nav.methodology">Metodología</a>
+          <a href="#testimonios" data-i18n="nav.testimonials">Testimonios</a>
+          <a href="#contacto" data-i18n="nav.contact">Contacto</a>
+          <a
+            class="site-nav__cta"
+            href="https://wa.me/5491162576017"
+            target="_blank"
+            rel="noopener"
+            data-i18n="nav.whatsapp"
+          >
             WhatsApp directo
           </a>
+          <button
+            type="button"
+            class="language-toggle"
+            id="language-toggle"
+            data-i18n="language.toggle"
+            data-i18n-attr="aria-label:language.toggleLabel"
+            aria-label="Cambiar a inglés"
+          >
+            EN
+          </button>
         </nav>
       </div>
       <div class="hero">
-        <p class="hero__kicker">Soluciones legales y contables a medida</p>
-        <h1 class="hero__title">Estudio Meraki</h1>
-        <p class="hero__lead">
+        <p class="hero__kicker" data-i18n="hero.kicker">Soluciones legales y contables a medida</p>
+        <h1 class="hero__title" data-i18n="hero.title">Estudio Meraki</h1>
+        <p class="hero__lead" data-i18n="hero.lead">
           Acompañamos a personas, familias y empresas con una mirada integral. Nos enfocamos en la
           escucha activa, el análisis preciso y la creación de estrategias que generen confianza a largo
           plazo.
         </p>
         <div class="hero__actions">
-          <a class="button button--primary" href="#servicios">Conocé nuestros servicios</a>
-          <a class="button" href="#contacto">Reservá una reunión</a>
+          <a class="button button--primary" href="#servicios" data-i18n="hero.primaryCta">Conocé nuestros servicios</a>
+          <a class="button" href="#contacto" data-i18n="hero.secondaryCta">Reservá una reunión</a>
         </div>
         <ul class="hero__metrics" role="list">
           <li class="hero__metric">
-            <span class="hero__metric-value">+12 años</span>
-            <span class="hero__metric-label">De experiencia interdisciplinaria</span>
+            <span class="hero__metric-value" data-i18n="hero.metric1Value">+12 años</span>
+            <span class="hero__metric-label" data-i18n="hero.metric1Label">De experiencia interdisciplinaria</span>
           </li>
           <li class="hero__metric">
-            <span class="hero__metric-value">96%</span>
-            <span class="hero__metric-label">De consultas resueltas en menos de 48 h</span>
+            <span class="hero__metric-value" data-i18n="hero.metric2Value">96%</span>
+            <span class="hero__metric-label" data-i18n="hero.metric2Label">De consultas resueltas en menos de 48 h</span>
           </li>
           <li class="hero__metric">
-            <span class="hero__metric-value">5.0</span>
-            <span class="hero__metric-label">Promedio de satisfacción de clientes</span>
+            <span class="hero__metric-value" data-i18n="hero.metric3Value">5.0</span>
+            <span class="hero__metric-label" data-i18n="hero.metric3Label">Promedio de satisfacción de clientes</span>
           </li>
         </ul>
       </div>
@@ -67,9 +87,9 @@
     <main>
       <section class="about" id="sobre-el-estudio">
         <div class="section-heading">
-          <span class="section-heading__eyebrow">Sobre el estudio</span>
-          <h2>Un equipo interdisciplinario comprometido con tus proyectos</h2>
-          <p>
+          <span class="section-heading__eyebrow" data-i18n="about.eyebrow">Sobre el estudio</span>
+          <h2 data-i18n="about.title">Un equipo interdisciplinario comprometido con tus proyectos</h2>
+          <p data-i18n="about.lead">
             Somos abogados y contadores que unen experiencia jurídica y contable para acompañarte con un
             servicio personalizado. Diseñamos soluciones que contemplan la dimensión humana, financiera y
             legal de cada caso.
@@ -77,22 +97,22 @@
         </div>
         <div class="about__grid">
           <article class="about-card">
-            <h3>👥 Acompañamiento cercano</h3>
-            <p>
+            <h3 data-i18n="about.card1Title">👥 Acompañamiento cercano</h3>
+            <p data-i18n="about.card1Body">
               Generamos vínculos de confianza a través de reuniones periódicas, seguimiento activo y
               comunicación clara en cada instancia del proceso.
             </p>
           </article>
           <article class="about-card">
-            <h3>📚 Actualización permanente</h3>
-            <p>
+            <h3 data-i18n="about.card2Title">📚 Actualización permanente</h3>
+            <p data-i18n="about.card2Body">
               Participamos en capacitaciones y redes profesionales para ofrecerte respuestas ágiles basadas
               en la normativa vigente y las mejores prácticas del mercado.
             </p>
           </article>
           <article class="about-card">
-            <h3>🤝 Visión integral</h3>
-            <p>
+            <h3 data-i18n="about.card3Title">🤝 Visión integral</h3>
+            <p data-i18n="about.card3Body">
               Articulamos la mirada legal y contable para anticipar riesgos, optimizar recursos y diseñar
               estrategias sostenibles para tu vida o negocio.
             </p>
@@ -102,9 +122,9 @@
 
       <section class="team" id="equipo">
         <div class="section-heading">
-          <span class="section-heading__eyebrow">Equipo profesional</span>
-          <h2>Abogados y contadores que combinan visión estratégica y humana</h2>
-          <p>
+          <span class="section-heading__eyebrow" data-i18n="team.eyebrow">Equipo profesional</span>
+          <h2 data-i18n="team.title">Abogados y contadores que combinan visión estratégica y humana</h2>
+          <p data-i18n="team.lead">
             Conocé a quienes lideran cada especialidad. Su experiencia académica y de campo respalda las
             soluciones integrales que ofrecemos día a día.
           </p>
@@ -117,27 +137,28 @@
                   class="team-card__photo"
                   src="assets/Julieta.jpeg"
                   alt="Fotografía de Julieta Elizabeth Cardinali Merani"
+                  data-i18n-attr="alt:team.julieta.alt"
                 />
               </div>
               <div class="team-card__identity">
-                <h3>Julieta Elizabeth Cardinali Merani</h3>
-                <p class="team-card__role">Abogada</p>
-                <p class="team-card__location">Ciudad Autónoma y Provincia de Buenos Aires</p>
+                <h3 data-i18n="team.julieta.name">Julieta Elizabeth Cardinali Merani</h3>
+                <p class="team-card__role" data-i18n="team.julieta.role">Abogada</p>
+                <p class="team-card__location" data-i18n="team.julieta.location">Ciudad Autónoma y Provincia de Buenos Aires</p>
               </div>
             </div>
-            <p class="team-card__bio">
+            <p class="team-card__bio" data-i18n="team.julieta.bio">
               Lidera el abordaje integral de asuntos de familia e
               inmobiliarios, priorizando la escucha activa y las soluciones colaborativas.
             </p>
             <ul class="team-card__highlights">
-              <li><span aria-hidden="true">🎓</span> Abogacía (UADE) con orientación en derecho privado</li>
-              <li><span aria-hidden="true">⚖️</span> Especialista en derecho de familia y sucesiones</li>
-              <li><span aria-hidden="true">📜</span> Diplomada en derecho inmobiliario registral</li>
+              <li data-i18n="team.julieta.highlight1"><span aria-hidden="true">🎓</span> Abogacía (UADE) con orientación en derecho privado</li>
+              <li data-i18n="team.julieta.highlight2"><span aria-hidden="true">⚖️</span> Especialista en derecho de familia y sucesiones</li>
+              <li data-i18n="team.julieta.highlight3"><span aria-hidden="true">📜</span> Diplomada en derecho inmobiliario registral</li>
             </ul>
-            <div class="team-card__tags" aria-label="Áreas principales de Julieta">
-              <span>Derecho de familia</span>
-              <span>Sucesiones</span>
-              <span>Derecho inmobiliario</span>
+            <div class="team-card__tags" aria-label="Áreas principales de Julieta" data-i18n-attr="aria-label:team.julieta.tagsLabel">
+              <span data-i18n="team.julieta.tag1">Derecho de familia</span>
+              <span data-i18n="team.julieta.tag2">Sucesiones</span>
+              <span data-i18n="team.julieta.tag3">Derecho inmobiliario</span>
             </div>
             <div class="team-card__cta">
               <a
@@ -145,6 +166,7 @@
                 href="https://wa.me/5491162576017?text=Hola%20Julieta,%20quiero%20asesoramiento%20legal"
                 target="_blank"
                 rel="noopener"
+                data-i18n="team.consultCta"
               >
                 Agendar consulta
               </a>
@@ -156,28 +178,29 @@
                 class="team-card__avatar team-card__avatar--initials"
                 role="img"
                 aria-label="Iniciales de Viviana Elizabeth Merani"
+                data-i18n-attr="aria-label:team.viviana.initials"
               >
                 <span class="team-card__initials" aria-hidden="true">VM</span>
               </div>
               <div class="team-card__identity">
-                <h3>Viviana Elizabeth Merani</h3>
-                <p class="team-card__role">Abogada</p>
-                <p class="team-card__location">Ciudad Autónoma y Provincia de Buenos Aires</p>
+                <h3 data-i18n="team.viviana.name">Viviana Elizabeth Merani</h3>
+                <p class="team-card__role" data-i18n="team.viviana.role">Abogada</p>
+                <p class="team-card__location" data-i18n="team.viviana.location">Ciudad Autónoma y Provincia de Buenos Aires</p>
               </div>
             </div>
-            <p class="team-card__bio">
+            <p class="team-card__bio" data-i18n="team.viviana.bio">
               Conduce estrategias integrales en derecho civil, comercial y laboral, priorizando la prevención de
               conflictos mediante acuerdos sostenibles y acompañamiento personalizado.
             </p>
             <ul class="team-card__highlights">
-              <li><span aria-hidden="true">🎓</span> Abogada (UBA) con posgrado en derecho civil y comercial</li>
-              <li><span aria-hidden="true">⚖️</span> Mediadora prejudicial matriculada con enfoque en resolución colaborativa</li>
-              <li><span aria-hidden="true">🤝</span> Amplia experiencia en asesoramiento a pymes y familias empresarias</li>
+              <li data-i18n="team.viviana.highlight1"><span aria-hidden="true">🎓</span> Abogada (UBA) con posgrado en derecho civil y comercial</li>
+              <li data-i18n="team.viviana.highlight2"><span aria-hidden="true">⚖️</span> Mediadora prejudicial matriculada con enfoque en resolución colaborativa</li>
+              <li data-i18n="team.viviana.highlight3"><span aria-hidden="true">🤝</span> Amplia experiencia en asesoramiento a pymes y familias empresarias</li>
             </ul>
-            <div class="team-card__tags" aria-label="Áreas principales de Viviana">
-              <span>Derecho civil</span>
-              <span>Derecho comercial</span>
-              <span>Mediación</span>
+            <div class="team-card__tags" aria-label="Áreas principales de Viviana" data-i18n-attr="aria-label:team.viviana.tagsLabel">
+              <span data-i18n="team.viviana.tag1">Derecho civil</span>
+              <span data-i18n="team.viviana.tag2">Derecho comercial</span>
+              <span data-i18n="team.viviana.tag3">Mediación</span>
             </div>
             <div class="team-card__cta">
               <a
@@ -185,6 +208,7 @@
                 href="https://wa.me/5491162576017?text=Hola%20Viviana,%20necesito%20asesoramiento%20legal"
                 target="_blank"
                 rel="noopener"
+                data-i18n="team.consultCta"
               >
                 Agendar consulta
               </a>
@@ -197,27 +221,28 @@
                   class="team-card__photo"
                   src="assets/Alberto.jpeg"
                   alt="Fotografía de Alberto Lassa"
+                  data-i18n-attr="alt:team.alberto.alt"
                 />
               </div>
               <div class="team-card__identity">
-                <h3>Alberto Lassa</h3>
-                <p class="team-card__role">Contador Público</p>
-                <p class="team-card__location">Ciudad Autónoma y Provincia de Buenos Aires</p>
+                <h3 data-i18n="team.alberto.name">Alberto Lassa</h3>
+                <p class="team-card__role" data-i18n="team.alberto.role">Contador Público</p>
+                <p class="team-card__location" data-i18n="team.alberto.location">Ciudad Autónoma y Provincia de Buenos Aires</p>
               </div>
             </div>
-            <p class="team-card__bio">
+            <p class="team-card__bio" data-i18n="team.alberto.bio">
               Coordina los servicios contables e impositivos del estudio, acompañando a empresas y
               emprendedores con planificación fiscal, cumplimiento normativo y reportes financieros claros.
             </p>
             <ul class="team-card__highlights">
-              <li><span aria-hidden="true">📊</span> Más de 30 años asesorando en impuestos nacionales y provinciales</li>
-              <li><span aria-hidden="true">🏢</span> Experto en armado de estructuras societarias y balances ante IGJ</li>
-              <li><span aria-hidden="true">🤝</span> Especialista en liquidación de haberes y convenios colectivos</li>
+              <li data-i18n="team.alberto.highlight1"><span aria-hidden="true">📊</span> Más de 30 años asesorando en impuestos nacionales y provinciales</li>
+              <li data-i18n="team.alberto.highlight2"><span aria-hidden="true">🏢</span> Experto en armado de estructuras societarias y balances ante IGJ</li>
+              <li data-i18n="team.alberto.highlight3"><span aria-hidden="true">🤝</span> Especialista en liquidación de haberes y convenios colectivos</li>
             </ul>
-            <div class="team-card__tags" aria-label="Áreas principales de Alberto">
-              <span>Planificación fiscal</span>
-              <span>Sociedades</span>
-              <span>Liquidación de sueldos</span>
+            <div class="team-card__tags" aria-label="Áreas principales de Alberto" data-i18n-attr="aria-label:team.alberto.tagsLabel">
+              <span data-i18n="team.alberto.tag1">Planificación fiscal</span>
+              <span data-i18n="team.alberto.tag2">Sociedades</span>
+              <span data-i18n="team.alberto.tag3">Liquidación de sueldos</span>
             </div>
             <div class="team-card__cta">
               <a
@@ -225,6 +250,7 @@
                 href="https://wa.me/5491162576017?text=Hola%20Alberto,%20necesito%20asesoramiento%20contable"
                 target="_blank"
                 rel="noopener"
+                data-i18n="team.consultCta"
               >
                 Agendar consulta
               </a>
@@ -237,27 +263,28 @@
                   class="team-card__photo"
                   src="assets/Agustin.jpeg"
                   alt="Fotografía de Agustin Lescano"
+                  data-i18n-attr="alt:team.agustin.alt"
                 />
               </div>
               <div class="team-card__identity">
-                <h3>Agustin Lescano</h3>
-                <p class="team-card__role">Abogado</p>
-                <p class="team-card__location">Ciudad Autónoma y Provincia de Buenos Aires</p>
+                <h3 data-i18n="team.agustin.name">Agustin Lescano</h3>
+                <p class="team-card__role" data-i18n="team.agustin.role">Abogado</p>
+                <p class="team-card__location" data-i18n="team.agustin.location">Ciudad Autónoma y Provincia de Buenos Aires</p>
               </div>
             </div>
-            <p class="team-card__bio">
+            <p class="team-card__bio" data-i18n="team.agustin.bio">
               Lidera el asesoramiento laboral del estudio, acompañando a trabajadores y pymes en negociaciones,
               auditorías y estrategias de prevención de conflictos.
             </p>
             <ul class="team-card__highlights">
-              <li><span aria-hidden="true">🎓</span> Abogado (UBA) con especialización en derecho penal y laboral</li>
-              <li><span aria-hidden="true">📑</span> Docente Universitario</li>
-              <li><span aria-hidden="true">⚖️</span> Maestria en Derecho Laboral</li>
+              <li data-i18n="team.agustin.highlight1"><span aria-hidden="true">🎓</span> Abogado (UBA) con especialización en derecho penal y laboral</li>
+              <li data-i18n="team.agustin.highlight2"><span aria-hidden="true">📑</span> Docente Universitario</li>
+              <li data-i18n="team.agustin.highlight3"><span aria-hidden="true">⚖️</span> Maestria en Derecho Laboral</li>
             </ul>
-            <div class="team-card__tags" aria-label="Áreas principales de Agustin">
-              <span>Derecho laboral</span>
-              <span>Negociaciones colectivas</span>
-              <span>Prevención de conflictos</span>
+            <div class="team-card__tags" aria-label="Áreas principales de Agustin" data-i18n-attr="aria-label:team.agustin.tagsLabel">
+              <span data-i18n="team.agustin.tag1">Derecho laboral</span>
+              <span data-i18n="team.agustin.tag2">Negociaciones colectivas</span>
+              <span data-i18n="team.agustin.tag3">Prevención de conflictos</span>
             </div>
             <div class="team-card__cta">
               <a
@@ -265,6 +292,7 @@
                 href="https://wa.me/5491162576017?text=Hola%20Agustin,%20necesito%20asesoramiento%20laboral"
                 target="_blank"
                 rel="noopener"
+                data-i18n="team.consultCta"
               >
                 Agendar consulta
               </a>
@@ -275,23 +303,23 @@
 
       <section class="services" id="servicios">
         <div class="section-heading section-heading--center">
-          <span class="section-heading__eyebrow">Áreas de práctica</span>
-          <h2>Seleccioná el asesoramiento que necesitás</h2>
-          <p>
+          <span class="section-heading__eyebrow" data-i18n="services.eyebrow">Áreas de práctica</span>
+          <h2 data-i18n="services.title">Seleccioná el asesoramiento que necesitás</h2>
+          <p data-i18n="services.lead">
             Desplegá cada especialidad para conocer las gestiones en las que podemos acompañarte. Si tenés
             un caso particular, escribinos y armamos una propuesta a medida.
           </p>
         </div>
         <div class="services__groups">
           <div class="services__group">
-            <h3 class="services__group-title">Servicios legales</h3>
+            <h3 class="services__group-title" data-i18n="services.legal.title">Servicios legales</h3>
             <div class="service-accordion" role="list">
               <details class="service-accordion__item" open>
                 <summary>
-                  <span class="service-accordion__title">🏡 Derecho inmobiliario</span>
+                  <span class="service-accordion__title" data-i18n="services.legal.inmobiliario.summary">🏡 Derecho inmobiliario</span>
                   <span class="service-accordion__icon" aria-hidden="true"></span>
                 </summary>
-                <ul>
+                <ul data-i18n="services.legal.inmobiliario.items">
                   <li>Boleto de compraventa y seguimiento de escrituración</li>
                   <li>Contratos de locación para vivienda, comerciales y temporarios</li>
                   <li>Due diligence y asesoría integral en operaciones inmobiliarias</li>
@@ -302,10 +330,10 @@
 
               <details class="service-accordion__item">
                 <summary>
-                  <span class="service-accordion__title">👨‍👩‍👧 Derecho de familia</span>
+                  <span class="service-accordion__title" data-i18n="services.legal.familia.summary">👨‍👩‍👧 Derecho de familia</span>
                   <span class="service-accordion__icon" aria-hidden="true"></span>
                 </summary>
-                <ul>
+                <ul data-i18n="services.legal.familia.items">
                   <li>Divorcios de común acuerdo o contenciosos</li>
                   <li>Convenios de alimentos, cuidado personal y régimen de comunicación</li>
                   <li>Sucesiones y planificación hereditaria</li>
@@ -316,10 +344,10 @@
 
               <details class="service-accordion__item">
                 <summary>
-                  <span class="service-accordion__title">💼 Derecho laboral</span>
+                  <span class="service-accordion__title" data-i18n="services.legal.laboral.summary">💼 Derecho laboral</span>
                   <span class="service-accordion__icon" aria-hidden="true"></span>
                 </summary>
-                <ul>
+                <ul data-i18n="services.legal.laboral.items">
                   <li>Asesoramiento a empleadores y trabajadores</li>
                   <li>Reclamos por despidos, accidentes laborales e indemnizaciones</li>
                   <li>Liquidaciones finales y cálculo de haberes</li>
@@ -330,10 +358,10 @@
 
               <details class="service-accordion__item">
                 <summary>
-                  <span class="service-accordion__title">📄 Derecho comercial y societario</span>
+                  <span class="service-accordion__title" data-i18n="services.legal.comercial.summary">📄 Derecho comercial y societario</span>
                   <span class="service-accordion__icon" aria-hidden="true"></span>
                 </summary>
-                <ul>
+                <ul data-i18n="services.legal.comercial.items">
                   <li>Constitución de sociedades (SRL, SA, SAS) y acuerdos societarios</li>
                   <li>Redacción de estatutos, actas y contratos comerciales</li>
                   <li>Due diligence y reorganizaciones empresariales</li>
@@ -344,10 +372,10 @@
 
               <details class="service-accordion__item">
                 <summary>
-                  <span class="service-accordion__title">⚖️ Derecho civil</span>
+                  <span class="service-accordion__title" data-i18n="services.legal.civil.summary">⚖️ Derecho civil</span>
                   <span class="service-accordion__icon" aria-hidden="true"></span>
                 </summary>
-                <ul>
+                <ul data-i18n="services.legal.civil.items">
                   <li>Redacción y revisión de contratos civiles</li>
                   <li>Reclamos por daños y perjuicios</li>
                   <li>Cobro de deudas y ejecuciones</li>
@@ -358,10 +386,10 @@
 
               <details class="service-accordion__item">
                 <summary>
-                  <span class="service-accordion__title">🛡️ Derecho penal</span>
+                  <span class="service-accordion__title" data-i18n="services.legal.penal.summary">🛡️ Derecho penal</span>
                   <span class="service-accordion__icon" aria-hidden="true"></span>
                 </summary>
-                <ul>
+                <ul data-i18n="services.legal.penal.items">
                   <li>Defensa en causas penales en todas las instancias</li>
                   <li>Presentación de denuncias y querellas</li>
                   <li>Asistencia a víctimas y medidas de protección</li>
@@ -373,14 +401,14 @@
           </div>
 
           <div class="services__group">
-            <h3 class="services__group-title">Servicios contables</h3>
+            <h3 class="services__group-title" data-i18n="services.accounting.title">Servicios contables</h3>
             <div class="service-accordion" role="list">
               <details class="service-accordion__item">
                 <summary>
-                  <span class="service-accordion__title">📘 Contabilidad general</span>
+                  <span class="service-accordion__title" data-i18n="services.accounting.general.summary">📘 Contabilidad general</span>
                   <span class="service-accordion__icon" aria-hidden="true"></span>
                 </summary>
-                <ul>
+                <ul data-i18n="services.accounting.general.items">
                   <li>Armado de libros contables obligatorios (diario, inventario y balances)</li>
                   <li>Registración de operaciones contables</li>
                   <li>Elaboración de estados contables (balance general, estado de resultados)</li>
@@ -391,10 +419,10 @@
 
               <details class="service-accordion__item">
                 <summary>
-                  <span class="service-accordion__title">🧾 Impositivos y fiscales</span>
+                  <span class="service-accordion__title" data-i18n="services.accounting.tax.summary">🧾 Impositivos y fiscales</span>
                   <span class="service-accordion__icon" aria-hidden="true"></span>
                 </summary>
-                <ul>
+                <ul data-i18n="services.accounting.tax.items">
                   <li>Inscripción y categorización en AFIP (monotributo, responsable inscripto)</li>
                   <li>Liquidación de impuestos nacionales (IVA, Ganancias, Bienes Personales)</li>
                   <li>Liquidación de impuestos provinciales (Ingresos Brutos, Sellos)</li>
@@ -406,10 +434,10 @@
 
               <details class="service-accordion__item">
                 <summary>
-                  <span class="service-accordion__title">🏢 Sociedades y emprendimientos</span>
+                  <span class="service-accordion__title" data-i18n="services.accounting.business.summary">🏢 Sociedades y emprendimientos</span>
                   <span class="service-accordion__icon" aria-hidden="true"></span>
                 </summary>
-                <ul>
+                <ul data-i18n="services.accounting.business.items">
                   <li>Constitución de sociedades (SRL, SA, SAS)</li>
                   <li>Asesoramiento en estructura societaria y estatutos</li>
                   <li>Presentación de balances ante IGJ o DPPJ</li>
@@ -420,10 +448,10 @@
 
               <details class="service-accordion__item">
                 <summary>
-                  <span class="service-accordion__title">🧑‍💼 Laborales y previsionales</span>
+                  <span class="service-accordion__title" data-i18n="services.accounting.labor.summary">🧑‍💼 Laborales y previsionales</span>
                   <span class="service-accordion__icon" aria-hidden="true"></span>
                 </summary>
-                <ul>
+                <ul data-i18n="services.accounting.labor.items">
                   <li>Alta de empleadores en AFIP</li>
                   <li>Liquidación de sueldos y cargas sociales</li>
                   <li>Generación de recibos de sueldo</li>
@@ -438,9 +466,9 @@
       </section>
       <section class="process" id="metodologia">
         <div class="section-heading section-heading--center">
-          <span class="section-heading__eyebrow">Metodología Meraki</span>
-          <h2>Trabajamos con un proceso claro y acompañado</h2>
-          <p>
+          <span class="section-heading__eyebrow" data-i18n="process.eyebrow">Metodología Meraki</span>
+          <h2 data-i18n="process.title">Trabajamos con un proceso claro y acompañado</h2>
+          <p data-i18n="process.lead">
             Desde el primer contacto hasta el cierre del caso mantenemos una comunicación transparente
             para que sepas en qué instancia estamos y cuáles son los siguientes
             pasos.
@@ -449,32 +477,32 @@
         <div class="process__steps">
           <article class="process-step">
             <span class="process-step__badge" aria-hidden="true">1</span>
-            <h3>Diagnóstico inicial</h3>
-            <p>
+            <h3 data-i18n="process.step1Title">Diagnóstico inicial</h3>
+            <p data-i18n="process.step1Body">
               Escuchamos tu consulta en detalle y recopilamos la documentación necesaria para entender el
               contexto legal y/o contable.
             </p>
           </article>
           <article class="process-step">
             <span class="process-step__badge" aria-hidden="true">2</span>
-            <h3>Estrategia a medida</h3>
-            <p>
+            <h3 data-i18n="process.step2Title">Estrategia a medida</h3>
+            <p data-i18n="process.step2Body">
               Diseñamos un plan integral que contempla riesgos, oportunidades y tiempos estimados, y lo
               validamos con vos antes de avanzar.
             </p>
           </article>
           <article class="process-step">
             <span class="process-step__badge" aria-hidden="true">3</span>
-            <h3>Ejecución y seguimiento</h3>
-            <p>
+            <h3 data-i18n="process.step3Title">Ejecución y seguimiento</h3>
+            <p data-i18n="process.step3Body">
               Gestionamos cada instancia operativa con reportes periódicos, reuniones de actualización y
               acceso a la documentación digital.
             </p>
           </article>
           <article class="process-step">
             <span class="process-step__badge" aria-hidden="true">4</span>
-            <h3>Cierre y acompañamiento</h3>
-            <p>
+            <h3 data-i18n="process.step4Title">Cierre y acompañamiento</h3>
+            <p data-i18n="process.step4Body">
               Presentamos los resultados, definimos próximos pasos y quedamos disponibles para el soporte
               continuo que necesites.
             </p>
@@ -483,42 +511,42 @@
       </section>
       <section class="testimonials" id="testimonios">
         <div class="section-heading section-heading--center">
-          <span class="section-heading__eyebrow">Experiencias reales</span>
-          <h2>Las personas que nos eligen hablan de nuestro compromiso</h2>
-          <p>
+          <span class="section-heading__eyebrow" data-i18n="testimonials.eyebrow">Experiencias reales</span>
+          <h2 data-i18n="testimonials.title">Las personas que nos eligen hablan de nuestro compromiso</h2>
+          <p data-i18n="testimonials.lead">
             Historias de pymes, familias y emprendedores que confiaron en el Estudio Meraki para resolver
             procesos sensibles y estratégicos.
           </p>
         </div>
         <div class="testimonials__grid">
           <figure class="testimonial-card">
-            <blockquote>
+            <blockquote data-i18n="testimonials.quote1">
               “Nos acompañaron en la reorganización societaria y logramos ordenar la documentación sin
               detener la operación del negocio. La disponibilidad del equipo fue clave.”
             </blockquote>
             <figcaption>
-              <span class="testimonial-card__name">Lucía Fernández</span>
-              <span class="testimonial-card__role">Directora de Pyme tecnológica</span>
+              <span class="testimonial-card__name" data-i18n="testimonials.name1">Lucía Fernández</span>
+              <span class="testimonial-card__role" data-i18n="testimonials.role1">Directora de Pyme tecnológica</span>
             </figcaption>
           </figure>
           <figure class="testimonial-card">
-            <blockquote>
+            <blockquote data-i18n="testimonials.quote2">
               “Encontré una escucha humana en un momento complejo de mi familia. El plan de acción fue
               claro y me sentí acompañada en cada etapa del proceso.”
             </blockquote>
             <figcaption>
-              <span class="testimonial-card__name">Martina Thompson</span>
-              <span class="testimonial-card__role">Cliente de derecho de familia</span>
+              <span class="testimonial-card__name" data-i18n="testimonials.name2">Martina Thompson</span>
+              <span class="testimonial-card__role" data-i18n="testimonials.role2">Cliente de derecho de familia</span>
             </figcaption>
           </figure>
           <figure class="testimonial-card">
-            <blockquote>
+            <blockquote data-i18n="testimonials.quote3">
               “El seguimiento mensual contable e impositivo nos permitió anticipar vencimientos y mejorar el
               flujo de caja. Hoy tomamos decisiones con información clara.”
             </blockquote>
             <figcaption>
-              <span class="testimonial-card__name">Gonzalo Schuster</span>
-              <span class="testimonial-card__role">Cliente pyme industria textil</span>
+              <span class="testimonial-card__name" data-i18n="testimonials.name3">Gonzalo Schuster</span>
+              <span class="testimonial-card__role" data-i18n="testimonials.role3">Cliente pyme industria textil</span>
             </figcaption>
           </figure>
         </div>
@@ -526,95 +554,148 @@
       <section class="cta-banner" aria-labelledby="cta-banner-heading">
         <div class="cta-banner__inner">
           <div class="cta-banner__content">
-            <span class="section-heading__eyebrow">Agenda inteligente</span>
-            <h2 id="cta-banner-heading">Reservá una consulta virtual</h2>
-            <p>
+            <span class="section-heading__eyebrow" data-i18n="cta.eyebrow">Agenda inteligente</span>
+            <h2 id="cta-banner-heading" data-i18n="cta.title">Reservá una consulta virtual</h2>
+            <p data-i18n="cta.lead">
               Coordinamos una videollamada de 20 minutos para evaluar tu caso y sugerirte el plan de trabajo
               ideal. Recibí un resumen con los próximos pasos y honorarios estimados.
             </p>
           </div>
           <div class="cta-banner__actions">
-            <a class="button button--primary" href="https://wa.me/5491162576017" target="_blank" rel="noopener">
+            <a
+              class="button button--primary"
+              href="https://wa.me/5491162576017"
+              target="_blank"
+              rel="noopener"
+              data-i18n="cta.primaryCta"
+            >
               Agenda por WhatsApp
             </a>
-            <a class="button button--ghost" href="#contacto">Quiero dejar mi consulta</a>
+            <a class="button button--ghost" href="#contacto" data-i18n="cta.secondaryCta">Quiero dejar mi consulta</a>
           </div>
         </div>
       </section>
       <section class="chatbot" id="asistente">
         <div class="section-heading section-heading--center">
-          <span class="section-heading__eyebrow">Asistente virtual</span>
-          <h2>Chateá con Meraki para resolver tus dudas rápidas</h2>
-          <p>
+          <span class="section-heading__eyebrow" data-i18n="chatbot.eyebrow">Asistente virtual</span>
+          <h2 data-i18n="chatbot.title">Chateá con Meraki para resolver tus dudas rápidas</h2>
+          <p data-i18n="chatbot.lead">
             Consultá sobre nuestras áreas de asesoramiento o pedí los datos de contacto. Nuestro asistente te
             orienta y, si el caso lo requiere, te comparte los medios para hablar directamente con el equipo.
           </p>
         </div>
         <div class="chatbot__widget">
           <div class="chatbot__messages" id="chatbot-messages" aria-live="polite"></div>
-          <div class="chatbot__suggestions" aria-label="Consultas sugeridas">
-            <button type="button" data-question="Quisiera conocer los servicios legales disponibles">
+          <div
+            class="chatbot__suggestions"
+            aria-label="Consultas sugeridas"
+            data-i18n-attr="aria-label:chatbot.suggestionsLabel"
+          >
+            <button
+              type="button"
+              data-question="Quisiera conocer los servicios legales disponibles"
+              data-i18n="chatbot.suggestion1"
+              data-i18n-attr="data-question:chatbot.suggestion1Question"
+            >
               Servicios legales
             </button>
-            <button type="button" data-question="Necesito información sobre los servicios contables">
+            <button
+              type="button"
+              data-question="Necesito información sobre los servicios contables"
+              data-i18n="chatbot.suggestion2"
+              data-i18n-attr="data-question:chatbot.suggestion2Question"
+            >
               Servicios contables
             </button>
-            <button type="button" data-question="Quiero asesoramiento en derecho inmobiliario">
+            <button
+              type="button"
+              data-question="Quiero asesoramiento en derecho inmobiliario"
+              data-i18n="chatbot.suggestion3"
+              data-i18n-attr="data-question:chatbot.suggestion3Question"
+            >
               Derecho inmobiliario
             </button>
-            <button type="button" data-question="Busco ayuda en contabilidad general">
+            <button
+              type="button"
+              data-question="Busco ayuda en contabilidad general"
+              data-i18n="chatbot.suggestion4"
+              data-i18n-attr="data-question:chatbot.suggestion4Question"
+            >
               Contabilidad general
             </button>
-            <button type="button" data-question="Necesito apoyo con impuestos y fiscalizaciones">
+            <button
+              type="button"
+              data-question="Necesito apoyo con impuestos y fiscalizaciones"
+              data-i18n="chatbot.suggestion5"
+              data-i18n-attr="data-question:chatbot.suggestion5Question"
+            >
               Impositivos y fiscales
             </button>
-            <button type="button" data-question="Quiero saber más sobre sociedades y emprendimientos">
+            <button
+              type="button"
+              data-question="Quiero saber más sobre sociedades y emprendimientos"
+              data-i18n="chatbot.suggestion6"
+              data-i18n-attr="data-question:chatbot.suggestion6Question"
+            >
               Sociedades y emprendimientos
             </button>
-            <button type="button" data-question="Me interesa el servicio laboral y previsional contable">
+            <button
+              type="button"
+              data-question="Me interesa el servicio laboral y previsional contable"
+              data-i18n="chatbot.suggestion7"
+              data-i18n-attr="data-question:chatbot.suggestion7Question"
+            >
               Laborales y previsionales
             </button>
-            <button type="button" data-question="¿Cuál es el teléfono de contacto?">Datos de contacto</button>
+            <button
+              type="button"
+              data-question="¿Cuál es el teléfono de contacto?"
+              data-i18n="chatbot.suggestion8"
+              data-i18n-attr="data-question:chatbot.suggestion8Question"
+            >
+              Datos de contacto
+            </button>
           </div>
           <form class="chatbot__form" id="chatbot-form">
-            <label class="visually-hidden" for="chatbot-input">Escribí tu consulta</label>
+            <label class="visually-hidden" for="chatbot-input" data-i18n="chatbot.inputLabel">Escribí tu consulta</label>
             <input
               id="chatbot-input"
               name="mensaje"
               type="text"
               autocomplete="off"
               placeholder="Escribí tu consulta acá..."
+              data-i18n-attr="placeholder:chatbot.placeholder"
               required
             />
-            <button type="submit" class="button button--primary">Enviar</button>
+            <button type="submit" class="button button--primary" data-i18n="chatbot.submit">Enviar</button>
           </form>
         </div>
       </section>
 
       <section class="contact" id="contacto">
         <div class="section-heading">
-          <span class="section-heading__eyebrow">Agendemos una reunión</span>
-          <h2>Contanos en qué podemos ayudarte</h2>
-          <p>
+          <span class="section-heading__eyebrow" data-i18n="contact.eyebrow">Agendemos una reunión</span>
+          <h2 data-i18n="contact.title">Contanos en qué podemos ayudarte</h2>
+          <p data-i18n="contact.lead">
             Elegí el medio que prefieras o completá el formulario. Respondemos dentro de las 24 horas
             hábiles con los próximos pasos para tu consulta.
           </p>
         </div>
         <div class="contact__grid">
           <article class="contact-card">
-            <h3>Datos de contacto</h3>
+            <h3 data-i18n="contact.cardTitle">Datos de contacto</h3>
             <ul>
               <li>
-                <span>Teléfono</span>
+                <span data-i18n="contact.phoneLabel">Teléfono</span>
                 <a href="tel:+5491162576017">+54 9 11 6257-6017</a>
               </li>
               <li>
-                <span>Email</span>
+                <span data-i18n="contact.emailLabel">Email</span>
                 <a href="mailto:ejcmeraki@gmail.com">ejcmeraki@gmail.com</a>
               </li>
               <li>
-                <span>Dirección</span>
-                <address>
+                <span data-i18n="contact.addressLabel">Dirección</span>
+                <address data-i18n="contact.address">
                   <p>
                     <span aria-hidden="true">📍</span>
                     Guardia Vieja 3732 4 E<br />
@@ -628,15 +709,21 @@
                 </address>
               </li>
               <li>
-                <span>Horarios</span>
-                <p>Lunes a Viernes de 9 a 18 h</p>
+                <span data-i18n="contact.hoursLabel">Horarios</span>
+                <p data-i18n="contact.hours">Lunes a Viernes de 9 a 18 h</p>
               </li>
             </ul>
             <div class="contact-card__cta">
-              <a class="button button--ghost" href="https://wa.me/5491162576017" target="_blank" rel="noopener">
+              <a
+                class="button button--ghost"
+                href="https://wa.me/5491162576017"
+                target="_blank"
+                rel="noopener"
+                data-i18n="contact.whatsappCta"
+              >
                 Escribir por WhatsApp
               </a>
-              <a class="button button--ghost" href="mailto:ejcmeraki@gmail.com">Enviar correo</a>
+              <a class="button button--ghost" href="mailto:ejcmeraki@gmail.com" data-i18n="contact.emailCta">Enviar correo</a>
             </div>
           </article>
 
@@ -646,22 +733,22 @@
             action="https://formsubmit.co/ejcmeraki@gmail.com"
             method="post"
           >
-            <h3>Enviá tu consulta</h3>
+            <h3 data-i18n="contact.formTitle">Enviá tu consulta</h3>
             <label class="form__field">
-              <span>Nombre completo</span>
-              <input type="text" name="nombre" placeholder="María Pérez" required />
+              <span data-i18n="contact.formName">Nombre completo</span>
+              <input type="text" name="nombre" placeholder="María Pérez" required data-i18n-attr="placeholder:contact.formNamePlaceholder" />
             </label>
             <label class="form__field">
-              <span>Email</span>
-              <input type="email" name="email" placeholder="nombre@correo.com" required />
+              <span data-i18n="contact.formEmail">Email</span>
+              <input type="email" name="email" placeholder="nombre@correo.com" required data-i18n-attr="placeholder:contact.formEmailPlaceholder" />
             </label>
             <label class="form__field">
-              <span>Teléfono</span>
-              <input type="tel" name="telefono" placeholder="11 2345 6789" />
+              <span data-i18n="contact.formPhone">Teléfono</span>
+              <input type="tel" name="telefono" placeholder="11 2345 6789" data-i18n-attr="placeholder:contact.formPhonePlaceholder" />
             </label>
             <label class="form__field">
-              <span>Motivo de la consulta</span>
-              <select name="motivo" required>
+              <span data-i18n="contact.formReason">Motivo de la consulta</span>
+              <select name="motivo" required data-i18n="contact.formReasonOptions">
                 <option value="" disabled selected>Elegí una opción</option>
                 <option value="inmobiliario">Derecho inmobiliario</option>
                 <option value="familia">Derecho de familia</option>
@@ -677,14 +764,19 @@
               </select>
             </label>
             <label class="form__field form__field--textarea">
-              <span>Contanos más detalles</span>
-              <textarea name="mensaje" rows="4" placeholder="Describí tu consulta"></textarea>
+              <span data-i18n="contact.formDetails">Contanos más detalles</span>
+              <textarea
+                name="mensaje"
+                rows="4"
+                placeholder="Describí tu consulta"
+                data-i18n-attr="placeholder:contact.formDetailsPlaceholder"
+              ></textarea>
             </label>
-            <input type="hidden" name="_subject" value="Nueva consulta desde el sitio web" />
+            <input type="hidden" name="_subject" value="Nueva consulta desde el sitio web" data-i18n-attr="value:contact.formSubject" />
             <input type="hidden" name="_captcha" value="false" />
-            <button type="submit" class="button button--primary">Enviar consulta</button>
+            <button type="submit" class="button button--primary" data-i18n="contact.formSubmit">Enviar consulta</button>
             <p class="form__status" id="contact-form-status" aria-live="polite"></p>
-            <p class="form__disclaimer">
+            <p class="form__disclaimer" data-i18n="contact.formDisclaimer">
               Al enviar tus datos aceptás ser contactado/a por un representante del Estudio Meraki.
             </p>
           </form>
@@ -693,324 +785,17 @@
     </main>
 
     <footer class="site-footer">
-      <p>© <span id="year"></span> Estudio Meraki. Todos los derechos reservados.</p>
-      <nav aria-label="Navegación en el pie" class="site-footer__nav">
-        <a href="#inicio">Inicio</a>
-        <a href="#sobre-el-estudio">El estudio</a>
-        <a href="#servicios">Servicios</a>
-        <a href="#metodologia">Metodología</a>
-        <a href="#testimonios">Testimonios</a>
-        <a href="#contacto">Contacto</a>
+      <p data-i18n="footer.copy">© <span id="year"></span> Estudio Meraki. Todos los derechos reservados.</p>
+      <nav aria-label="Navegación en el pie" class="site-footer__nav" data-i18n-attr="aria-label:footer.navLabel">
+        <a href="#inicio" data-i18n="footer.home">Inicio</a>
+        <a href="#sobre-el-estudio" data-i18n="footer.study">El estudio</a>
+        <a href="#servicios" data-i18n="footer.services">Servicios</a>
+        <a href="#metodologia" data-i18n="footer.methodology">Metodología</a>
+        <a href="#testimonios" data-i18n="footer.testimonials">Testimonios</a>
+        <a href="#contacto" data-i18n="footer.contact">Contacto</a>
       </nav>
     </footer>
 
-    <script>
-      const yearElement = document.getElementById("year");
-      if (yearElement) {
-        yearElement.textContent = new Date().getFullYear();
-      }
-
-      const chatbotMessages = document.getElementById("chatbot-messages");
-      const chatbotForm = document.getElementById("chatbot-form");
-      const chatbotInput = document.getElementById("chatbot-input");
-      const chatbotSuggestionButtons = document.querySelectorAll(
-        ".chatbot__suggestions button[data-question]"
-      );
-
-      const contactDetails =
-        "Podés comunicarte al +54 9 11 6257-6017 (WhatsApp o llamada) o escribirnos a ejcmeraki@gmail.com. También podés visitarnos en Guardia Vieja 3732 4 E, Almagro, CABA.";
-
-      const knowledgeBase = [
-        {
-          match: /(hola|buen[oa]s (d[ií]as|tardes|noches)|hey|qué tal|que tal|saludo)/,
-          response:
-            "¡Hola! Soy el asistente virtual del Estudio Meraki. ¿En qué puedo ayudarte hoy?",
-        },
-        {
-          match: /(gracias|muchas gracias|te agradezco|muy amable)/,
-          response:
-            "¡Gracias a vos por escribirnos! Si necesitás algo más, contanos y seguimos en contacto.",
-        },
-        {
-          match:
-            /(qu[ié]n sos|quien sos|qu[ié]nes son|quienes son|qu[eé] es meraki|que es meraki|sobre ustedes|qu[eé] hacen)/,
-          response:
-            "Somos un equipo interdisciplinario de abogadas y contadoras. Acompañamos a personas, familias y empresas con soluciones legales y contables integrales.",
-        },
-        {
-          match: /(experiencia|equipo|profesionales|trayectoria|interdisciplinario)/,
-          response:
-            "Trabajamos de manera interdisciplinaria, combinando la mirada legal y contable para ofrecer respuestas ágiles y personalizadas a cada consulta.",
-        },
-        {
-          match: /(servicio legal|servicios legales|área legal|area legal|abogad)/,
-          response:
-            "Nuestros servicios legales incluyen derecho inmobiliario, de familia, laboral, comercial y societario, civil y penal. Contanos tu caso y te conectamos con el equipo jurídico indicado.",
-        },
-        {
-          match: /(servicio contable|servicios contables|contable|contabilidad|estudio contable)/,
-          response:
-            "Desde el área contable te acompañamos con contabilidad general, impuestos y fiscalizaciones, sociedades y emprendimientos, y gestiones laborales y previsionales. Contame qué necesitás y te guiamos paso a paso.",
-        },
-        {
-          match: /inmobiliari|alquiler|alquilar|escritura|escrituraci|fideicomiso|propiedad|venta/,
-          response:
-            "En derecho inmobiliario te asistimos en boletos de compraventa, contratos de alquiler, escrituración y fideicomisos. Coordinamos todo el proceso para que tu operación sea segura.",
-        },
-        {
-          match: /familia|divorci|alimento|cuidad|régimen|regimen|adopci|filiaci|violencia/,
-          response:
-            "El área de familia acompaña divorcios, convenios de alimentos y cuidado personal, sucesiones, adopciones y situaciones de violencia familiar con un enfoque humano y cercano.",
-        },
-        {
-          match:
-            /laboral y previsional|contabilidad laboral|liquidaci[óo]n de sueldos|cargas sociales|recibos de sueldo|alta de empleadores|empleadores en afip|altas y bajas de empleados|sipa|obra social|\bart\b|convenios colectivos|legislaci[óo]n laboral|liquidaciones finales contables/,
-          response:
-            "En materia laboral y previsional gestionamos el alta de empleadores en AFIP, la liquidación de sueldos y cargas sociales, la generación de recibos, las altas y bajas de personal en SIPA, ART u obra social, el asesoramiento en convenios colectivos y el cálculo de indemnizaciones y liquidaciones finales.",
-        },
-        {
-          match: /laboral|trabaj|despido|liquidaci|indemnizaci|accidente/,
-          response:
-            "Nuestro equipo laboral asesora a personas y empresas en despidos, liquidaciones, indemnizaciones, accidentes de trabajo y negociaciones ante el Ministerio de Trabajo.",
-        },
-        {
-          match: /societari|comercial|empresa|sociedad|estatuto|s\.?a|srl|sas|contrato comercial/,
-          response:
-            "En derecho comercial y societario constituimos sociedades (SRL, SA, SAS), redactamos estatutos y contratos, y acompañamos reorganizaciones y cumplimiento normativo.",
-        },
-        {
-          match: /civil|contrato civil|daño|perjuicio|deuda|ejecuci|amparo|mediaci/,
-          response:
-            "El área civil cubre redacción de contratos, reclamos por daños, cobro de deudas, acciones de amparo y soluciones extrajudiciales.",
-        },
-        {
-          match: /penal|denuncia|querella|excarcelaci|delito|victima|víctima/,
-          response:
-            "En derecho penal brindamos defensa en todas las instancias, presentación de denuncias y querellas, medidas de protección y planes de compliance preventivo.",
-        },
-        {
-          match:
-            /contabilidad general|libro[s]? contable[s]?|registraci[óo]n contable|estado[s]? contable[s]?|certificaci[óo]n contable[s]?|auditor[íi]a(s)?/,
-          response:
-            "En contabilidad general armamos los libros obligatorios, registramos operaciones, elaboramos estados contables, emitimos certificaciones para trámites bancarios o judiciales y realizamos auditorías internas y externas.",
-        },
-        {
-          match:
-            /impositiv|impuesto|afip|monotribut|ganancias|iva|bienes personales|arba|ingresos brutos|sellos|declaraci[óo]n jurada|retenci[óo]n|percepci[óo]n|fiscalizaci[óo]n|inscripci[óo]n|categorizaci[óo]n/,
-          response:
-            "El área impositiva se encarga de la inscripción y categorización en AFIP, la liquidación de impuestos nacionales y provinciales, la presentación de declaraciones juradas y la atención de requerimientos o fiscalizaciones, incluyendo regímenes de retención y percepción.",
-        },
-        {
-          match:
-            /sociedades y emprendimientos|balance ante igj|balances ante igj|dppj|cnv|planificaci[óo]n fiscal y contable|estructura societaria|tr[aá]mites ante organismos p[úu]blicos|pymes y emprendedores/,
-          response:
-            "Acompañamos a sociedades y emprendimientos con la constitución de figuras como SRL, SA o SAS, el armado de estructuras y estatutos, la presentación de balances ante IGJ o DPPJ, los trámites ante organismos como AFIP, IGJ o CNV y la planificación fiscal para pymes y emprendedores.",
-        },
-        {
-          match: /(servicio|servicios|asesoramiento|ayuda|consulta|especialidad|área|area)/,
-          response:
-            "Contamos con asesoramiento legal (inmobiliario, familia, laboral, comercial y societario, civil y penal) y contable (contabilidad general, impuestos, sociedades y emprendimientos, laborales y previsionales). Contame brevemente tu situación y te indico el equipo ideal.",
-        },
-        {
-          match: /(reuni[óo]n|reunion|agendar|reservar|turno|agenda|coordinar)/,
-          response:
-            "Coordinamos reuniones presenciales en Almagro o virtuales según tu disponibilidad. Escribinos por WhatsApp o completá el formulario y te proponemos un horario.",
-        },
-        {
-          match: /(modalidad|virtual|online|videollamada|presencial|distancia|remoto)/,
-          response:
-            "Podemos trabajar de forma presencial en nuestro estudio o virtualmente. Elegí la modalidad que prefieras y adaptamos la reunión a tu agenda.",
-        },
-        {
-          match: /(costo|costos|precio|tarifa|honorario|presupuesto|cu[áa]nto sale|cuanto sale)/,
-          response:
-            "Los honorarios dependen del tipo de consulta y la complejidad del caso. Contactanos por WhatsApp o correo y armamos una propuesta a medida.",
-        },
-        {
-          match: /(tiempo de respuesta|cu[áa]nto tardan|cuanto tardan|demoran|respuesta)/,
-          response:
-            "Respondemos las consultas dentro de las 24 horas hábiles. Si necesitás algo urgente, escribinos por WhatsApp y te respondemos a la brevedad.",
-        },
-        {
-          match: /(documentaci[óo]n|documentos|requisitos|informaci[óo]n previa)/,
-          response:
-            "Podés acercarnos los documentos disponibles y te indicamos si hace falta algo más para avanzar. Te ayudamos a ordenar toda la información necesaria.",
-        },
-        {
-          match: /horario|hora|atenci|disponibilidad|agenda|turno/,
-          response:
-            "Atendemos de lunes a viernes de 9 a 18 h. Podemos coordinar una reunión presencial o virtual según tu disponibilidad.",
-        },
-        {
-          match: /direcci|ubicaci|dónde están|donde estan/,
-          response:
-            "Estamos en Guardia Vieja 3732 4 E, en el barrio de Almagro, Ciudad Autónoma de Buenos Aires. Te esperamos con cita previa.",
-        },
-        {
-          match: /correo|mail|email|escribir|contacto|tel[eé]fono|whatsapp|llamar|comunicar/,
-          response: contactDetails,
-        },
-        {
-          match: /(gracias por la ayuda|muy claro|perfecto|genial)/,
-          response:
-            "¡Me alegra que la información te sirva! Si aparece otra duda, escribime cuando quieras.",
-        },
-        {
-          match: /(adios|chau|hasta luego|nos vemos)/,
-          response:
-            "¡Hasta luego! Cuando quieras retomar la conversación, escribinos y seguimos charlando.",
-        },
-      ];
-
-      const fallbackAnswer =
-        "No estoy seguro de haber entendido tu consulta. " + contactDetails;
-
-      function formatTime(date) {
-        return date.toLocaleTimeString("es-AR", {
-          hour: "2-digit",
-          minute: "2-digit",
-        });
-      }
-
-      function addMessage(role, text) {
-        if (!chatbotMessages) return;
-        const bubble = document.createElement("div");
-        bubble.classList.add("chatbot__bubble", `chatbot__bubble--${role}`);
-
-        const messageText = document.createElement("p");
-        messageText.textContent = text;
-        bubble.appendChild(messageText);
-
-        const timestamp = document.createElement("time");
-        const now = new Date();
-        timestamp.dateTime = now.toISOString();
-        timestamp.textContent = formatTime(now);
-        bubble.appendChild(timestamp);
-
-        chatbotMessages.appendChild(bubble);
-        chatbotMessages.scrollTop = chatbotMessages.scrollHeight;
-      }
-
-      function findResponse(message) {
-        const normalized = message.toLowerCase();
-
-        const directContactKeywords = /(tel[eé]fono|whatsapp|contacto directo|correo|email|llamar|celular|celu)/;
-        if (directContactKeywords.test(normalized)) {
-          return contactDetails;
-        }
-
-        for (const item of knowledgeBase) {
-          if (item.match.test(normalized)) {
-            return item.response;
-          }
-        }
-
-        return fallbackAnswer;
-      }
-
-      function handleUserMessage(message) {
-        const trimmed = message.trim();
-        if (!trimmed) return;
-        addMessage("user", trimmed);
-
-        window.setTimeout(() => {
-          const reply = findResponse(trimmed);
-          addMessage("bot", reply);
-        }, 350);
-      }
-
-      if (chatbotForm && chatbotInput) {
-        chatbotForm.addEventListener("submit", (event) => {
-          event.preventDefault();
-          const userMessage = chatbotInput.value;
-          chatbotInput.value = "";
-          handleUserMessage(userMessage);
-        });
-      }
-
-      chatbotSuggestionButtons.forEach((button) => {
-        button.addEventListener("click", () => {
-          const { question } = button.dataset;
-          if (!question) return;
-          if (chatbotInput) {
-            chatbotInput.value = "";
-            chatbotInput.focus();
-          }
-          handleUserMessage(question);
-        });
-      });
-
-      if (chatbotMessages) {
-        addMessage(
-          "bot",
-          "Hola, soy el asistente virtual del Estudio Meraki. Contame si necesitás asesoramiento legal o contable y te orientaré."
-        );
-      }
-
-      const contactForm = document.getElementById("contact-form");
-      const contactFormStatus = document.getElementById("contact-form-status");
-
-      function setContactStatus(message, type) {
-        if (!contactFormStatus) return;
-        contactFormStatus.textContent = message;
-        contactFormStatus.classList.remove("form__status--success", "form__status--error");
-        if (type) {
-          contactFormStatus.classList.add(`form__status--${type}`);
-        }
-      }
-
-      async function handleContactFormSubmit(event) {
-        if (!contactForm) return;
-        event.preventDefault();
-
-        const submitButton = contactForm.querySelector('button[type="submit"]');
-        const originalButtonText = submitButton ? submitButton.textContent : "";
-
-        if (submitButton) {
-          submitButton.disabled = true;
-          submitButton.textContent = "Enviando...";
-        }
-
-        setContactStatus("Enviando tu consulta...", "");
-
-        try {
-          const formData = new FormData(contactForm);
-          const response = await fetch("https://formsubmit.co/ajax/ejcmeraki@gmail.com", {
-            method: "POST",
-            headers: { Accept: "application/json" },
-            body: formData,
-          });
-
-          if (!response.ok) {
-            const data = await response.json().catch(() => null);
-            const errorMessage =
-              (data && (data.message || data.error)) ||
-              "No pudimos enviar el formulario en este momento. Escribinos a ejcmeraki@gmail.com o por WhatsApp.";
-            setContactStatus(errorMessage, "error");
-            return;
-          }
-
-          setContactStatus(
-            "¡Gracias! Recibimos tu consulta y te contactaremos dentro de las próximas 24 horas hábiles.",
-            "success"
-          );
-          contactForm.reset();
-        } catch (error) {
-          setContactStatus(
-            "Ocurrió un inconveniente al enviar tu consulta. Por favor escribinos a ejcmeraki@gmail.com o por WhatsApp.",
-            "error"
-          );
-        } finally {
-          if (submitButton) {
-            submitButton.disabled = false;
-            submitButton.textContent = originalButtonText || "Enviar consulta";
-          }
-        }
-      }
-
-      if (contactForm && window.fetch) {
-        contactForm.addEventListener("submit", handleContactFormSubmit);
-      }
-    </script>
+    <script src="app.js"></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -145,6 +145,24 @@ a:focus {
   color: #fff;
 }
 
+.language-toggle {
+  border: 2px solid rgba(255, 255, 255, 0.45);
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  padding: 0.45rem 0.9rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.language-toggle:hover,
+.language-toggle:focus {
+  border-color: rgba(255, 255, 255, 0.85);
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+}
+
 .hero {
   max-width: 720px;
   margin: clamp(2.5rem, 5vw, 4rem) auto 0;


### PR DESCRIPTION
## Summary
- add translation hooks across the landing page and introduce a language toggle in the navigation
- extract localization, chatbot replies, and form messaging into a new app.js script with Spanish and English support
- style the language toggle to match the existing header aesthetics

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbfa9c5ec08332baa2ff805dbccfb9