### PR TITLE
Add interactive map to contact section

### DIFF
--- a/index.html
+++ b/index.html
@@ -783,6 +783,15 @@
             </p>
           </form>
         </div>
+        <div class="contact-map" aria-label="Mapa con ubicaciones del Estudio Meraki">
+          <iframe
+            src="https://www.google.com/maps/embed?pb=!1m28!1m12!1m3!1d13135.653833792114!2d-58.38914445!3d-34.60449315!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m13!3e0!4m5!1s0x95bccb423df3fd6f%3A0xb3ca81a2c57d2057!2sGuardia%20Vieja%203732%2C%20C1192AAJ%20CABA!3m2!1d-34.6039967!2d-58.4142976!4m5!1s0x95a334b8d32c812d%3A0x3d89f913f2fe068!2sAlicia%20Moreau%20de%20Justo%20740%2C%20C1107%20CABA!3m2!1d-34.6080341!2d-58.3668842!5e0!3m2!1ses-419!2sar!4v1710351590134!5m2!1ses-419!2sar"
+            allowfullscreen=""
+            loading="lazy"
+            referrerpolicy="no-referrer-when-downgrade"
+            title="Mapa interactivo de las oficinas de Estudio Meraki"
+          ></iframe>
+        </div>
       </section>
     </main>
 

--- a/styles.css
+++ b/styles.css
@@ -1102,6 +1102,21 @@ main {
   gap: 0.75rem;
 }
 
+.contact-map {
+  margin-top: clamp(2rem, 5vw, 3rem);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-soft);
+}
+
+.contact-map iframe {
+  display: block;
+  width: 100%;
+  min-height: 320px;
+  border: 0;
+  aspect-ratio: 16 / 9;
+}
+
 .form {
   background: #fff;
   border-radius: var(--radius-md);


### PR DESCRIPTION
## Summary
- embed a Google Maps iframe below the contact details to highlight both office locations
- add styling to present the map with responsive sizing and consistent visual treatment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc110b4dd083329e3024b7560f2c61