### PR TITLE
Refine high contrast mode presentation

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,8 +10,12 @@ const chatbotSuggestionButtons = document.querySelectorAll(
   ".chatbot__suggestions button[data-question]"
 );
 const languageToggle = document.getElementById("language-toggle");
+const highContrastToggle = document.getElementById("high-contrast-toggle");
 const contactForm = document.getElementById("contact-form");
 const contactFormStatus = document.getElementById("contact-form-status");
+const CONTRAST_STORAGE_KEY = "preferredContrastMode";
+const HIGH_CONTRAST_VALUE = "high";
+const STANDARD_CONTRAST_VALUE = "standard";
 
 const translations = {
   es: {
@@ -26,6 +30,10 @@ const translations = {
     "nav.whatsapp": "WhatsApp directo",
     "language.toggle": "EN",
     "language.toggleLabel": "Cambiar a inglés",
+    "accessibility.skipLink": "Saltar al contenido principal",
+    "accessibility.highContrast": "Alto contraste",
+    "accessibility.highContrastOffLabel": "Activar modo de alto contraste",
+    "accessibility.highContrastOnLabel": "Desactivar modo de alto contraste",
     "hero.kicker": "Soluciones legales y contables a medida",
     "hero.title": "Estudio Meraki",
     "hero.lead": "Acompañamos a personas, familias y empresas con una mirada integral. Nos enfocamos en la escucha activa, el análisis preciso y la creación de estrategias que generen confianza a largo plazo.",
@@ -258,6 +266,10 @@ const translations = {
     "nav.whatsapp": "Direct WhatsApp",
     "language.toggle": "ES",
     "language.toggleLabel": "Switch to Spanish",
+    "accessibility.skipLink": "Skip to main content",
+    "accessibility.highContrast": "High contrast",
+    "accessibility.highContrastOffLabel": "Enable high contrast mode",
+    "accessibility.highContrastOnLabel": "Disable high contrast mode",
     "hero.kicker": "Tailored legal and accounting solutions",
     "hero.title": "Meraki Firm",
     "hero.lead": "We support individuals, families, and companies with an integral approach. We focus on active listening, precise analysis, and crafting strategies that build long-term trust.",
@@ -626,6 +638,51 @@ function getTranslation(key, language = currentLanguage) {
   return fallbackDictionary[key] || "";
 }
 
+function syncHighContrastToggleState() {
+  if (!highContrastToggle) return;
+  const isHighContrast = document.body.classList.contains("is-high-contrast");
+  const labelKey = isHighContrast
+    ? "accessibility.highContrastOnLabel"
+    : "accessibility.highContrastOffLabel";
+  const ariaLabel = getTranslation(labelKey);
+  if (ariaLabel) {
+    highContrastToggle.setAttribute("aria-label", ariaLabel);
+    highContrastToggle.setAttribute("title", ariaLabel);
+  } else {
+    highContrastToggle.removeAttribute("title");
+  }
+  highContrastToggle.setAttribute("aria-pressed", String(isHighContrast));
+}
+
+function setHighContrastState(isEnabled, { persist = true } = {}) {
+  document.body.classList.toggle("is-high-contrast", isEnabled);
+  if (persist) {
+    localStorage.setItem(
+      CONTRAST_STORAGE_KEY,
+      isEnabled ? HIGH_CONTRAST_VALUE : STANDARD_CONTRAST_VALUE
+    );
+  }
+  syncHighContrastToggleState();
+}
+
+function initializeHighContrastPreference() {
+  const storedPreference = localStorage.getItem(CONTRAST_STORAGE_KEY);
+  if (storedPreference === HIGH_CONTRAST_VALUE) {
+    setHighContrastState(true, { persist: false });
+  } else if (storedPreference === STANDARD_CONTRAST_VALUE) {
+    setHighContrastState(false, { persist: false });
+  } else {
+    syncHighContrastToggleState();
+  }
+
+  if (highContrastToggle) {
+    highContrastToggle.addEventListener("click", () => {
+      const shouldEnable = !document.body.classList.contains("is-high-contrast");
+      setHighContrastState(shouldEnable);
+    });
+  }
+}
+
 function buildKnowledgeBase(language) {
   return knowledgeBaseDefinitions
     .map((definition) => {
@@ -726,6 +783,7 @@ function applyTranslations(language) {
   }
 
   rebuildTranslationDependentData(currentLanguage);
+  syncHighContrastToggleState();
 }
 
 function rebuildTranslationDependentData(language) {
@@ -799,6 +857,8 @@ if (languageToggle) {
     applyTranslations(nextLanguage);
   });
 }
+
+initializeHighContrastPreference();
 
 const contactFormSubmitHandler = async (event) => {
   if (!contactForm) return;

--- a/index.html
+++ b/index.html
@@ -14,6 +14,9 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
+    <a class="skip-link" href="#sobre-el-estudio" data-i18n="accessibility.skipLink">
+      Saltar al contenido principal
+    </a>
     <header class="site-header" id="inicio">
       <div class="hero-media" aria-hidden="true">
         <video class="hero-media__video" autoplay muted loop playsinline>
@@ -54,6 +57,16 @@
             aria-label="Cambiar a inglés"
           >
             EN
+          </button>
+          <button
+            type="button"
+            class="contrast-toggle"
+            id="high-contrast-toggle"
+            aria-pressed="false"
+            aria-label="Activar modo de alto contraste"
+          >
+            <span class="contrast-toggle__icon contrast-toggle__icon--sun" aria-hidden="true">☀️</span>
+            <span class="contrast-toggle__icon contrast-toggle__icon--moon" aria-hidden="true">🌙</span>
           </button>
         </nav>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -34,8 +34,34 @@ a {
 }
 
 a:hover,
-a:focus {
+a:focus-visible {
   color: var(--color-primary);
+}
+
+:focus-visible {
+  outline: 3px solid var(--color-primary);
+  outline-offset: 3px;
+}
+
+.skip-link {
+  position: absolute;
+  left: 50%;
+  top: 0.5rem;
+  transform: translate(-50%, -150%);
+  padding: 0.75rem 1.5rem;
+  background: var(--color-primary);
+  color: #fff;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 600;
+  box-shadow: 0 14px 30px rgba(37, 41, 82, 0.25);
+  z-index: 999;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.skip-link:focus-visible {
+  transform: translate(-50%, 0);
+  box-shadow: 0 18px 36px rgba(37, 41, 82, 0.3);
 }
 
 .visually-hidden {
@@ -152,12 +178,12 @@ a:focus {
 }
 
 .site-nav a:hover,
-.site-nav a:focus {
+.site-nav a:focus-visible {
   opacity: 1;
 }
 
 .site-header a:hover,
-.site-header a:focus {
+.site-header a:focus-visible {
   color: #fff;
 }
 
@@ -169,13 +195,14 @@ a:focus {
 }
 
 .site-nav__cta:hover,
-.site-nav__cta:focus {
+.site-nav__cta:focus-visible {
   border-color: rgba(255, 255, 255, 0.85);
   background: rgba(255, 255, 255, 0.15);
   color: #fff;
 }
 
-.language-toggle {
+.language-toggle,
+.contrast-toggle {
   border: 2px solid rgba(255, 255, 255, 0.45);
   border-radius: 999px;
   background: transparent;
@@ -184,13 +211,38 @@ a:focus {
   padding: 0.45rem 0.9rem;
   cursor: pointer;
   transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  line-height: 1;
 }
 
 .language-toggle:hover,
-.language-toggle:focus {
+.language-toggle:focus-visible,
+.contrast-toggle:hover,
+.contrast-toggle:focus-visible {
   border-color: rgba(255, 255, 255, 0.85);
   background: rgba(255, 255, 255, 0.15);
   color: #fff;
+}
+
+.contrast-toggle__icon {
+  font-size: 1.05rem;
+  transition: transform 0.25s ease, opacity 0.25s ease, filter 0.25s ease;
+}
+
+.contrast-toggle[aria-pressed="false"] .contrast-toggle__icon--sun,
+.contrast-toggle[aria-pressed="true"] .contrast-toggle__icon--moon {
+  opacity: 1;
+  transform: scale(1);
+  filter: drop-shadow(0 0 2px rgba(255, 255, 255, 0.35));
+}
+
+.contrast-toggle[aria-pressed="false"] .contrast-toggle__icon--moon,
+.contrast-toggle[aria-pressed="true"] .contrast-toggle__icon--sun {
+  opacity: 0.45;
+  transform: scale(0.85);
+  filter: none;
 }
 
 .hero {
@@ -996,7 +1048,6 @@ main {
 }
 
 .chatbot__suggestions button:hover,
-.chatbot__suggestions button:focus,
 .chatbot__suggestions button:focus-visible {
   background: var(--color-primary);
   color: #fff;
@@ -1021,7 +1072,7 @@ main {
   font-family: inherit;
 }
 
-.chatbot__form input:focus {
+.chatbot__form input:focus-visible {
   border-color: var(--color-primary);
   box-shadow: 0 0 0 4px rgba(50, 70, 148, 0.18);
   outline: none;
@@ -1184,9 +1235,9 @@ main {
   transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
-.form__field input:focus,
-.form__field select:focus,
-.form__field textarea:focus {
+.form__field input:focus-visible,
+.form__field select:focus-visible,
+.form__field textarea:focus-visible {
   outline: none;
   border-color: var(--color-primary);
   background: #fff;
@@ -1237,7 +1288,7 @@ main {
 }
 
 .button:hover,
-.button:focus {
+.button:focus-visible {
   transform: translateY(-2px);
   box-shadow: 0 14px 24px rgba(37, 41, 82, 0.18);
 }
@@ -1248,7 +1299,7 @@ main {
 }
 
 .button--primary:hover,
-.button--primary:focus {
+.button--primary:focus-visible {
   background: var(--color-primary-dark);
 }
 
@@ -1258,7 +1309,7 @@ main {
 }
 
 .button--ghost:hover,
-.button--ghost:focus {
+.button--ghost:focus-visible {
   border-color: rgba(50, 70, 148, 0.6);
   color: var(--color-primary-dark);
 }
@@ -1285,8 +1336,358 @@ main {
 }
 
 .site-footer__nav a:hover,
-.site-footer__nav a:focus {
+.site-footer__nav a:focus-visible {
   text-decoration: underline;
+}
+
+body.is-high-contrast {
+  background: #05070f;
+  color: #f4f7ff;
+  color-scheme: dark;
+}
+
+body.is-high-contrast a {
+  color: #ffd75a;
+}
+
+body.is-high-contrast a:hover,
+body.is-high-contrast a:focus-visible {
+  color: #fff1a8;
+}
+
+body.is-high-contrast :focus-visible {
+  outline-color: #ffd75a;
+}
+
+body.is-high-contrast .skip-link {
+  background: #ffd75a;
+  color: #05070f;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45);
+}
+
+body.is-high-contrast .site-header {
+  background: #02030a;
+  color: #f4f7ff;
+}
+
+body.is-high-contrast .site-header::before {
+  background: linear-gradient(115deg, rgba(2, 4, 12, 0.92), rgba(7, 12, 30, 0.85));
+}
+
+body.is-high-contrast .site-header::after {
+  background: radial-gradient(circle at 85% -10%, rgba(255, 215, 90, 0.45), transparent 55%);
+}
+
+body.is-high-contrast .site-header a:hover,
+body.is-high-contrast .site-header a:focus-visible {
+  color: #ffd75a;
+}
+
+body.is-high-contrast .site-nav__cta {
+  border-color: #ffd75a;
+  background: #ffd75a;
+  color: #05070f;
+  box-shadow: 0 0 0 2px rgba(255, 215, 90, 0.35);
+}
+
+body.is-high-contrast .site-nav__cta:hover,
+body.is-high-contrast .site-nav__cta:focus-visible {
+  background: transparent;
+  color: #ffd75a;
+  box-shadow: 0 0 0 2px rgba(255, 215, 90, 0.6);
+}
+
+body.is-high-contrast .language-toggle,
+body.is-high-contrast .contrast-toggle {
+  border-color: #ffd75a;
+  color: #ffd75a;
+}
+
+body.is-high-contrast .language-toggle:hover,
+body.is-high-contrast .language-toggle:focus-visible,
+body.is-high-contrast .contrast-toggle:hover,
+body.is-high-contrast .contrast-toggle:focus-visible {
+  background: #ffd75a;
+  color: #05070f;
+}
+
+body.is-high-contrast .hero__kicker,
+body.is-high-contrast .section-heading__eyebrow,
+body.is-high-contrast .team-card__role,
+body.is-high-contrast .service-accordion__item summary,
+body.is-high-contrast .form__field span,
+body.is-high-contrast .contact-card li span {
+  color: #ffd75a;
+}
+
+body.is-high-contrast .hero__lead,
+body.is-high-contrast .section-heading p,
+body.is-high-contrast .about-card p,
+body.is-high-contrast .team-card__bio,
+body.is-high-contrast .team-card__location,
+body.is-high-contrast .team-card__highlights,
+body.is-high-contrast .service-accordion__item ul,
+body.is-high-contrast .contact-card address,
+body.is-high-contrast .contact-card p,
+body.is-high-contrast .contact-map__address,
+body.is-high-contrast .form__disclaimer,
+body.is-high-contrast .form__status {
+  color: #e4e9ff;
+}
+
+body.is-high-contrast .section-heading h2 {
+  color: #f4f7ff;
+}
+
+body.is-high-contrast .about,
+body.is-high-contrast .services,
+body.is-high-contrast .process,
+body.is-high-contrast .testimonials,
+body.is-high-contrast .chatbot,
+body.is-high-contrast .contact {
+  background: #030815;
+  border: 2px solid rgba(255, 215, 90, 0.35);
+  box-shadow: 0 0 0 2px rgba(255, 215, 90, 0.18);
+}
+
+body.is-high-contrast .about-card,
+body.is-high-contrast .team-card,
+body.is-high-contrast .contact-card,
+body.is-high-contrast .contact-map,
+body.is-high-contrast .form {
+  background: #0d1426;
+  border: 2px solid rgba(255, 215, 90, 0.65);
+  box-shadow: 0 0 0 2px rgba(255, 215, 90, 0.45);
+  color: #f4f7ff;
+}
+
+body.is-high-contrast .about-card h3,
+body.is-high-contrast .team-card h3,
+body.is-high-contrast .contact-card h3,
+body.is-high-contrast .contact-map__title,
+body.is-high-contrast .form h3,
+body.is-high-contrast .services__group-title {
+  color: #ffd75a;
+}
+
+body.is-high-contrast .team-card::before {
+  background: rgba(255, 215, 90, 0.18);
+  opacity: 1;
+}
+
+body.is-high-contrast .team-card__tags span {
+  background: rgba(255, 215, 90, 0.12);
+  color: #ffd75a;
+}
+
+body.is-high-contrast .team-card__link {
+  background: #ffd75a;
+  color: #05070f;
+  border-color: #ffd75a;
+  box-shadow: 0 0 0 2px rgba(255, 215, 90, 0.35);
+}
+
+body.is-high-contrast .team-card__link:hover,
+body.is-high-contrast .team-card__link:focus-visible {
+  box-shadow: 0 0 0 3px rgba(255, 215, 90, 0.55);
+}
+
+body.is-high-contrast .team-card__link--ghost {
+  background: transparent;
+  color: #ffd75a;
+  border-color: rgba(255, 215, 90, 0.45);
+  box-shadow: none;
+}
+
+body.is-high-contrast .team-card__link--ghost:hover,
+body.is-high-contrast .team-card__link--ghost:focus-visible {
+  background: rgba(255, 215, 90, 0.18);
+  box-shadow: none;
+  color: #05070f;
+}
+
+body.is-high-contrast .process-step {
+  background: #0d1426;
+  border: 2px solid rgba(255, 215, 90, 0.4);
+  box-shadow: 0 0 0 2px rgba(255, 215, 90, 0.18);
+}
+
+body.is-high-contrast .process-step__badge {
+  background: #ffd75a;
+  color: #05070f;
+  box-shadow: 0 0 0 2px rgba(255, 215, 90, 0.35);
+}
+
+body.is-high-contrast .process-step h3 {
+  color: #f4f7ff;
+}
+
+body.is-high-contrast .process-step p {
+  color: #e4e9ff;
+}
+
+body.is-high-contrast .service-accordion__item {
+  background: #0d1426;
+  border: 2px solid rgba(255, 215, 90, 0.65);
+  box-shadow: none;
+}
+
+body.is-high-contrast .service-accordion__item[open] {
+  background: #040912;
+  box-shadow: 0 0 0 3px rgba(255, 215, 90, 0.35);
+}
+
+body.is-high-contrast .service-accordion__icon::before,
+body.is-high-contrast .service-accordion__item li::before {
+  color: #ffd75a;
+}
+
+body.is-high-contrast .button {
+  background: #ffd75a;
+  color: #05070f;
+  border-color: #ffd75a;
+  box-shadow: 0 0 0 2px rgba(255, 215, 90, 0.45);
+}
+
+body.is-high-contrast .button:hover,
+body.is-high-contrast .button:focus-visible {
+  box-shadow: 0 0 0 3px rgba(255, 215, 90, 0.6);
+}
+
+body.is-high-contrast .button--ghost {
+  background: transparent;
+  color: #ffd75a;
+  box-shadow: none;
+}
+
+body.is-high-contrast .button--ghost:hover,
+body.is-high-contrast .button--ghost:focus-visible {
+  background: #ffd75a;
+  color: #05070f;
+}
+
+body.is-high-contrast .chatbot__bubble--bot {
+  background: #111a33;
+  color: #f4f7ff;
+}
+
+body.is-high-contrast .chatbot__bubble--user {
+  background: #ffd75a;
+  color: #05070f;
+}
+
+body.is-high-contrast .testimonial-card {
+  background: #0d1426;
+  border: 2px solid rgba(255, 215, 90, 0.35);
+  box-shadow: 0 0 0 2px rgba(255, 215, 90, 0.18);
+}
+
+body.is-high-contrast .testimonial-card blockquote {
+  color: #f4f7ff;
+}
+
+body.is-high-contrast .testimonial-card blockquote::before {
+  color: rgba(255, 215, 90, 0.45);
+}
+
+body.is-high-contrast .testimonial-card__name {
+  color: #ffd75a;
+}
+
+body.is-high-contrast .testimonial-card__role {
+  color: #bcc6f9;
+}
+
+body.is-high-contrast .chatbot__messages {
+  background: #030815;
+  border: 2px solid rgba(255, 215, 90, 0.3);
+  box-shadow: inset 0 0 0 1px rgba(255, 215, 90, 0.2);
+}
+
+body.is-high-contrast .chatbot__messages::-webkit-scrollbar-thumb {
+  background: rgba(255, 215, 90, 0.45);
+}
+
+body.is-high-contrast .chatbot__messages::-webkit-scrollbar-track {
+  background: rgba(5, 9, 18, 0.85);
+}
+
+body.is-high-contrast .chatbot__suggestions button {
+  background: transparent;
+  border: 2px solid #ffd75a;
+  color: #ffd75a;
+  box-shadow: none;
+}
+
+body.is-high-contrast .chatbot__suggestions button:hover,
+body.is-high-contrast .chatbot__suggestions button:focus-visible {
+  background: #ffd75a;
+  color: #05070f;
+  box-shadow: 0 0 0 3px rgba(255, 215, 90, 0.45);
+}
+
+body.is-high-contrast .chatbot__form input {
+  background: #0d1426;
+  border: 2px solid rgba(255, 215, 90, 0.65);
+  color: #f4f7ff;
+}
+
+body.is-high-contrast .chatbot__form input::placeholder,
+body.is-high-contrast .form__field input::placeholder,
+body.is-high-contrast .form__field textarea::placeholder {
+  color: #bcc6f9;
+}
+
+body.is-high-contrast .chatbot__form input:focus-visible,
+body.is-high-contrast .form__field input:focus-visible,
+body.is-high-contrast .form__field select:focus-visible,
+body.is-high-contrast .form__field textarea:focus-visible {
+  box-shadow: 0 0 0 3px rgba(255, 215, 90, 0.45);
+  border-color: #ffd75a;
+  background: #02050f;
+}
+
+body.is-high-contrast .form__field input,
+body.is-high-contrast .form__field select,
+body.is-high-contrast .form__field textarea {
+  background: #0d1426;
+  border: 2px solid rgba(255, 215, 90, 0.65);
+  color: #f4f7ff;
+}
+
+body.is-high-contrast .form__status--success {
+  color: #6ef0b7;
+}
+
+body.is-high-contrast .form__status--error {
+  color: #ff9a9a;
+}
+
+body.is-high-contrast .site-footer {
+  background: #02030a;
+  color: #e4e9ff;
+}
+
+body.is-high-contrast .site-footer__nav a {
+  color: #ffd75a;
+}
+
+body.is-high-contrast .cta-banner__inner {
+  background: linear-gradient(135deg, #050912, #0d1a36);
+  box-shadow: 0 0 0 2px rgba(255, 215, 90, 0.35);
+}
+
+body.is-high-contrast .cta-banner__inner::after {
+  background: radial-gradient(circle, rgba(255, 215, 90, 0.35), transparent 60%);
+}
+
+body.is-high-contrast .cta-banner__content h2 {
+  color: #ffd75a;
+}
+
+body.is-high-contrast .cta-banner__content p,
+body.is-high-contrast .cta-banner__content .section-heading__eyebrow {
+  color: #e4e9ff;
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary
- replace the high contrast toggle label with sun and moon icons while keeping accessibility metadata in sync
- expand the high contrast palette to cover sections, cards, chatbot, and CTA surfaces for consistent dark styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc1bcf2f4883329c8b5dcbc6ea9ffd