### PR TITLE
Add dedicated 404 error page with bilingual support

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title data-i18n="error404.metaTitle">Estudio Meraki · Página no encontrada</title>
+    <meta
+      name="description"
+      content="No pudimos encontrar la página que buscás en Estudio Meraki. Volvé al inicio o contactanos para recibir asistencia."
+      data-i18n-attr="content:error404.metaDescription"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;700&family=Work+Sans:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      href="assets/LogoMeraki.png"
+      data-icon-standard="assets/LogoMeraki.png"
+      data-icon-high-contrast="assets/LogoMerakiAmarillo.png"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="error-page" data-title-key="error404.metaTitle">
+    <a class="skip-link" href="#contenido-principal" data-i18n="accessibility.skipLink">
+      Saltar al contenido principal
+    </a>
+    <header class="site-header site-header--error" id="inicio">
+      <div class="hero-media" aria-hidden="true">
+        <video class="hero-media__video" autoplay muted loop playsinline>
+          <source src="assets/VideoRascacielos.mp4" type="video/mp4" />
+          Tu navegador no soporta video HTML5.
+        </video>
+      </div>
+      <div class="site-header__inner">
+        <a class="brand" href="index.html" data-i18n-attr="aria-label:error404.homeLink" aria-label="Inicio">
+          <img
+            src="assets/LogoMeraki.png"
+            alt="Logotipo Estudio Meraki"
+            class="brand__image"
+            data-logo-standard="assets/LogoMeraki.png"
+            data-logo-high-contrast="assets/LogoMerakiAmarillo.png"
+          />
+        </a>
+        <nav class="site-nav site-nav--error" aria-label="Navegación principal" data-i18n-attr="aria-label:nav.label">
+          <a class="site-nav__cta" href="index.html" data-i18n="error404.homeLink">Inicio</a>
+          <a
+            class="site-nav__cta site-nav__cta--outline"
+            href="https://wa.me/5491162576017"
+            target="_blank"
+            rel="noopener"
+            data-i18n="error404.contactLink"
+          >
+            Contacto
+          </a>
+          <button
+            type="button"
+            class="language-toggle"
+            id="language-toggle"
+            data-i18n="language.toggle"
+            data-i18n-attr="aria-label:language.toggleLabel"
+            aria-label="Cambiar a inglés"
+          >
+            EN
+          </button>
+          <button
+            type="button"
+            class="contrast-toggle"
+            id="high-contrast-toggle"
+            aria-pressed="false"
+            aria-label="Activar modo de alto contraste"
+          >
+            <span class="contrast-toggle__icon contrast-toggle__icon--sun" aria-hidden="true">☀️</span>
+            <span class="contrast-toggle__icon contrast-toggle__icon--moon" aria-hidden="true">🌙</span>
+          </button>
+        </nav>
+      </div>
+      <div class="hero error-hero">
+        <p class="hero__kicker" data-i18n="error404.kicker">Error 404</p>
+        <h1 class="hero__title" data-i18n="error404.title">No encontramos la página que buscás</h1>
+        <p class="hero__lead" data-i18n="error404.lead">
+          Es posible que el enlace esté desactualizado o que la dirección se haya escrito con un error.
+        </p>
+        <div class="hero__actions">
+          <a class="button button--primary" href="index.html" data-i18n="error404.homeCta">Volver al inicio</a>
+          <a
+            class="button button--ghost"
+            href="mailto:ejcmeraki@gmail.com"
+            data-i18n="error404.contactCta"
+          >
+            Contactar al estudio
+          </a>
+        </div>
+      </div>
+    </header>
+    <main class="error-main" id="contenido-principal">
+      <section class="error-suggestions">
+        <div class="section-heading section-heading--center">
+          <span class="section-heading__eyebrow" data-i18n="error404.kicker">Error 404</span>
+          <h2 data-i18n="error404.suggestionsTitle">¿Qué podés hacer?</h2>
+          <p data-i18n="error404.suggestionsLead">Te dejamos algunos atajos para retomar el camino.</p>
+        </div>
+        <div class="error-suggestions__grid">
+          <article class="error-card">
+            <span class="error-card__icon" aria-hidden="true">🏠</span>
+            <h3 class="error-card__title" data-i18n="error404.option1Title">Explorar el sitio</h3>
+            <p class="error-card__body" data-i18n="error404.option1Body">
+              Visitá la <a class="error-card__link" href="index.html">página principal</a> para conocer nuestros servicios legales y contables.
+            </p>
+          </article>
+          <article class="error-card">
+            <span class="error-card__icon" aria-hidden="true">💬</span>
+            <h3 class="error-card__title" data-i18n="error404.option2Title">Contactar al equipo</h3>
+            <p class="error-card__body" data-i18n="error404.option2Body">
+              Escribinos por <a class="error-card__link" href="https://wa.me/5491162576017" target="_blank" rel="noopener">WhatsApp</a> o <a class="error-card__link" href="mailto:ejcmeraki@gmail.com">correo electrónico</a> y contanos cómo podemos ayudarte.
+            </p>
+          </article>
+          <article class="error-card">
+            <span class="error-card__icon" aria-hidden="true">↩️</span>
+            <h3 class="error-card__title" data-i18n="error404.option3Title">Volver a la página anterior</h3>
+            <p class="error-card__body" data-i18n="error404.option3Body">
+              Utilizá el botón de tu navegador para regresar y probar otro enlace o menú.
+            </p>
+          </article>
+        </div>
+      </section>
+    </main>
+    <footer class="site-footer">
+      <p data-i18n="footer.copy">© <span id="year"></span> Estudio Meraki. Todos los derechos reservados.</p>
+      <nav aria-label="Navegación en el pie" class="site-footer__nav" data-i18n-attr="aria-label:footer.navLabel">
+        <a href="index.html#inicio" data-i18n="footer.home">Inicio</a>
+        <a href="index.html#sobre-el-estudio" data-i18n="footer.study">El estudio</a>
+        <a href="index.html#servicios" data-i18n="footer.services">Servicios</a>
+        <a href="index.html#metodologia" data-i18n="footer.methodology">Metodología</a>
+        <a href="index.html#testimonios" data-i18n="footer.testimonials">Testimonios</a>
+        <a href="index.html#contacto" data-i18n="footer.contact">Contacto</a>
+      </nav>
+    </footer>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/app.js
+++ b/app.js
@@ -22,6 +22,23 @@ const STANDARD_CONTRAST_VALUE = "standard";
 const translations = {
   es: {
     "meta.title": "Estudio Meraki · Asesoramiento legal y contable",
+    "error404.metaTitle": "Estudio Meraki · Página no encontrada",
+    "error404.metaDescription": "No pudimos encontrar la página que buscás en Estudio Meraki. Volvé al inicio o contactanos para recibir asistencia.",
+    "error404.kicker": "Error 404",
+    "error404.title": "No encontramos la página que buscás",
+    "error404.lead": "Es posible que el enlace esté desactualizado o que la dirección se haya escrito con un error.",
+    "error404.homeCta": "Volver al inicio",
+    "error404.contactCta": "Contactar al estudio",
+    "error404.suggestionsTitle": "¿Qué podés hacer?",
+    "error404.suggestionsLead": "Te dejamos algunos atajos para retomar el camino.",
+    "error404.option1Title": "Explorar el sitio",
+    "error404.option1Body": "Visitá la <a class=\"error-card__link\" href=\"index.html\">página principal</a> para conocer nuestros servicios legales y contables.",
+    "error404.option2Title": "Contactar al equipo",
+    "error404.option2Body": "Escribinos por <a class=\"error-card__link\" href=\"https://wa.me/5491162576017\" target=\"_blank\" rel=\"noopener\">WhatsApp</a> o <a class=\"error-card__link\" href=\"mailto:ejcmeraki@gmail.com\">correo electrónico</a> y contanos cómo podemos ayudarte.",
+    "error404.option3Title": "Volver a la página anterior",
+    "error404.option3Body": "Utilizá el botón de tu navegador para regresar y probar otro enlace o menú.",
+    "error404.homeLink": "Inicio",
+    "error404.contactLink": "Contacto",
     "nav.study": "El estudio",
     "nav.team": "Equipo",
     "nav.services": "Servicios",
@@ -260,6 +277,23 @@ const translations = {
   },
   en: {
     "meta.title": "Meraki Firm · Legal and Accounting Advisory",
+    "error404.metaTitle": "Meraki Firm · Page not found",
+    "error404.metaDescription": "We couldn't find the page you were looking for at Meraki Firm. Head back to the homepage or contact us for assistance.",
+    "error404.kicker": "Error 404",
+    "error404.title": "We couldn’t find the page you need",
+    "error404.lead": "The link may be outdated or the address might contain a typo.",
+    "error404.homeCta": "Back to homepage",
+    "error404.contactCta": "Contact the firm",
+    "error404.suggestionsTitle": "What can you do?",
+    "error404.suggestionsLead": "Here are a few shortcuts to get you back on track.",
+    "error404.option1Title": "Explore the site",
+    "error404.option1Body": "Visit the <a class=\"error-card__link\" href=\"index.html\">homepage</a> to review our legal and accounting services.",
+    "error404.option2Title": "Reach out to the team",
+    "error404.option2Body": "Message us on <a class=\"error-card__link\" href=\"https://wa.me/5491162576017\" target=\"_blank\" rel=\"noopener\">WhatsApp</a> or <a class=\"error-card__link\" href=\"mailto:ejcmeraki@gmail.com\">email</a> and tell us how we can help.",
+    "error404.option3Title": "Go back to the previous page",
+    "error404.option3Body": "Use your browser’s back button to return and try another link or menu option.",
+    "error404.homeLink": "Home",
+    "error404.contactLink": "Contact",
     "nav.study": "The firm",
     "nav.team": "Team",
     "nav.services": "Services",
@@ -776,7 +810,8 @@ function applyTranslations(language) {
   document.documentElement.lang = currentLanguage;
   document.body.dataset.language = currentLanguage;
 
-  const title = getTranslation("meta.title");
+  const titleKey = document.body?.dataset?.titleKey || "meta.title";
+  const title = getTranslation(titleKey);
   if (title) {
     document.title = title;
   }

--- a/styles.css
+++ b/styles.css
@@ -1332,6 +1332,98 @@ main {
   color: var(--color-primary-dark);
 }
 
+body.error-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.site-header--error {
+  min-height: 70vh;
+  padding-bottom: clamp(3rem, 8vw, 6rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.site-nav--error {
+  gap: clamp(0.75rem, 2vw, 1.5rem);
+}
+
+.site-nav__cta--outline {
+  border-color: rgba(255, 255, 255, 0.45);
+}
+
+.site-nav__cta--outline:hover,
+.site-nav__cta--outline:focus-visible {
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+}
+
+.error-hero {
+  margin-top: clamp(3rem, 6vw, 5rem);
+  max-width: 720px;
+}
+
+.error-main {
+  flex: 1;
+  padding: clamp(3rem, 8vw, 5rem) clamp(1.5rem, 7vw, 4rem);
+  display: flex;
+  align-items: center;
+  background: linear-gradient(180deg, rgba(50, 70, 148, 0.04), rgba(243, 195, 114, 0.08));
+}
+
+.error-suggestions {
+  width: 100%;
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  gap: clamp(2rem, 5vw, 3rem);
+}
+
+.error-suggestions__grid {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.error-card {
+  background: #fff;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-soft);
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  display: grid;
+  gap: 1rem;
+}
+
+.error-card__icon {
+  font-size: 2rem;
+}
+
+.error-card__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.35rem;
+}
+
+.error-card__body {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+  line-height: 1.7;
+}
+
+.error-card__link {
+  font-weight: 600;
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.error-card__link:hover,
+.error-card__link:focus-visible {
+  text-decoration: underline;
+}
+
 .site-footer {
   padding: 3rem clamp(1.5rem, 6vw, 3.5rem);
   text-align: center;
@@ -1386,6 +1478,16 @@ body.is-high-contrast .skip-link {
 body.is-high-contrast .site-header {
   background: #02030a;
   color: #f4f7ff;
+}
+
+body.is-high-contrast .site-nav__cta--outline {
+  border-color: rgba(255, 215, 90, 0.55);
+}
+
+body.is-high-contrast .site-nav__cta--outline:hover,
+body.is-high-contrast .site-nav__cta--outline:focus-visible {
+  background: rgba(255, 215, 90, 0.2);
+  color: #05070f;
 }
 
 
@@ -1487,6 +1589,10 @@ body.is-high-contrast .contact {
   box-shadow: 0 0 0 2px rgba(255, 215, 90, 0.18);
 }
 
+body.is-high-contrast .error-main {
+  background: linear-gradient(180deg, rgba(8, 12, 24, 0.95), rgba(10, 16, 32, 0.75));
+}
+
 body.is-high-contrast .about-card,
 body.is-high-contrast .team-card,
 body.is-high-contrast .contact-card,
@@ -1496,6 +1602,25 @@ body.is-high-contrast .form {
   border: 2px solid rgba(255, 215, 90, 0.65);
   box-shadow: 0 0 0 2px rgba(255, 215, 90, 0.45);
   color: #f4f7ff;
+}
+
+body.is-high-contrast .error-card {
+  background: #0d1426;
+  border: 2px solid rgba(255, 215, 90, 0.65);
+  box-shadow: 0 0 0 2px rgba(255, 215, 90, 0.45);
+  color: #f4f7ff;
+}
+
+body.is-high-contrast .error-card__title {
+  color: #ffd75a;
+}
+
+body.is-high-contrast .error-card__body {
+  color: #e4e9ff;
+}
+
+body.is-high-contrast .error-card__link {
+  color: #ffd75a;
 }
 
 body.is-high-contrast .about-card h3,


### PR DESCRIPTION
## Summary
- add a localized 404.html page that matches the Meraki branding and guides visitors back to key actions
- extend the shared stylesheet with error-page layouts and high-contrast styling tweaks
- expand translations and title handling so the new page has bilingual copy and metadata

## Testing
- `python -m http.server 8000` (manual verification of /404.html)


------
https://chatgpt.com/codex/tasks/task_e_68dd43642cfc8332bf459f936d346b2f